### PR TITLE
PR 5 — ModBot chat Discord cog (sandbox-gated, rate-limited, monitor-coexistent)

### DIFF
--- a/bot/api_client.py
+++ b/bot/api_client.py
@@ -59,3 +59,27 @@ class BackendClient:
     async def set_demo_mode(self, enabled: bool) -> dict:
         """Toggle demo mode on or off."""
         return await self._post("/api/settings/demo-mode", {"enabled": enabled})
+
+    async def chat(
+        self,
+        *,
+        user_id: str,
+        channel_id: str,
+        guild_id: str,
+        content: str,
+    ) -> dict:
+        """POST /api/chat — returns {reply_text, session_id, refusal, provider_used}."""
+        return await self._post(
+            "/api/chat",
+            {
+                "user_id": user_id,
+                "channel_id": channel_id,
+                "guild_id": guild_id,
+                "content": content,
+            },
+        )
+
+    async def get_chat_enabled(self) -> bool:
+        """GET /api/settings/chat-enabled — return the chat-enabled DB flag."""
+        data = await self._get("/api/settings/chat-enabled")
+        return data.get("chat_enabled", True)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -18,6 +18,7 @@ COG_EXTENSIONS: list[str] = [
     "cogs.moddraft",
     "cogs.settings",
     "cogs.monitor",
+    "cogs.chat",
 ]
 
 

--- a/bot/chat_ratelimit.py
+++ b/bot/chat_ratelimit.py
@@ -1,0 +1,58 @@
+"""Sliding-window rate limiter for chat triggers."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+
+
+class ChatRateLimiter:
+    """
+    Sliding-window rate limiter for chat triggers.
+
+    Per-user:  N triggers per 60s
+    Per-guild: M triggers per 60s
+
+    Uses time.monotonic for clock skew safety. Memory-only (resets on bot
+    restart) — sufficient for v1; persistent quota tracking is PR 7 territory.
+
+    Semantics: a trigger is only "spent" if it is accepted. If the guild
+    window is full, neither the guild nor the user counter is incremented.
+    If the guild window has room but the user window is full, neither counter
+    is incremented. Both windows record the same trigger timestamp only when
+    allow() returns True.
+    """
+
+    def __init__(self, *, user_per_min: int, guild_per_min: int) -> None:
+        self.user_limit = user_per_min
+        self.guild_limit = guild_per_min
+        self._user_window: dict[str, deque[float]] = defaultdict(deque)
+        self._guild_window: dict[str, deque[float]] = defaultdict(deque)
+
+    def allow(self, *, user_id: str, guild_id: str) -> bool:
+        """Return True if the trigger should be allowed; False to drop.
+
+        Per-guild check runs first (cheaper fail-fast on a global flood).
+        Counters are only incremented when the trigger is accepted.
+        """
+        now = time.monotonic()
+        cutoff = now - 60.0
+
+        # Check & evict per-guild (fail fast on global flood)
+        gw = self._guild_window[guild_id]
+        while gw and gw[0] < cutoff:
+            gw.popleft()
+        if len(gw) >= self.guild_limit:
+            return False
+
+        # Check & evict per-user
+        uw = self._user_window[user_id]
+        while uw and uw[0] < cutoff:
+            uw.popleft()
+        if len(uw) >= self.user_limit:
+            return False
+
+        # Accept: record trigger in both windows
+        gw.append(now)
+        uw.append(now)
+        return True

--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -67,12 +67,35 @@ class ChatCog(commands.Cog):
 
         # Trigger gate: @mention OR reply-to-bot
         triggered_by_mention = self.bot.user in message.mentions
-        triggered_by_reply = (
-            message.reference is not None
-            and message.reference.resolved is not None
-            and isinstance(message.reference.resolved, discord.Message)
-            and message.reference.resolved.author.id == self.bot.user.id
-        )
+        triggered_by_reply = False
+
+        # Only check the reply path (potentially expensive) when mention didn't
+        # already trigger — avoids an HTTP call on every @-mention path.
+        if not triggered_by_mention and message.reference is not None:
+            resolved = message.reference.resolved
+            if isinstance(resolved, discord.Message):
+                triggered_by_reply = resolved.author.id == self.bot.user.id
+            elif resolved is None and message.reference.message_id is not None:
+                # Cache miss (e.g. bot restart, deep history) — fetch to determine
+                # the referenced message's author.  Fail closed on any error so a
+                # transient Discord fault can't accidentally trigger chat.
+                try:
+                    referenced = await message.channel.fetch_message(
+                        message.reference.message_id
+                    )
+                    triggered_by_reply = referenced.author.id == self.bot.user.id
+                except (discord.NotFound, discord.Forbidden):
+                    pass  # message inaccessible — treat as no trigger
+                except discord.HTTPException as exc:
+                    log.warning(
+                        "failed to fetch reply reference %s in channel %s: %s",
+                        message.reference.message_id,
+                        message.channel.id,
+                        exc,
+                    )
+            # discord.DeletedReferencedMessage and any other resolved type:
+            # leave triggered_by_reply=False
+
         if not (triggered_by_mention or triggered_by_reply):
             return
 

--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -1,0 +1,184 @@
+"""Conversational @ModBot listener — sandbox channel only."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import discord
+from discord.ext import commands
+
+from api_client import BackendClient
+from chat_ratelimit import ChatRateLimiter
+
+log = logging.getLogger(__name__)
+
+
+class ChatCog(commands.Cog):
+    """
+    Conversational @ModBot listener. Coexistence with MonitorCog is by design:
+    both fire on sandbox channel messages. Monitor handles moderation; this cog
+    handles casual chat.
+
+    When a human sends '@ModBot ...' in the sandbox:
+    - MonitorCog runs moderation analysis (always).
+    - ChatCog checks the mention/reply trigger and, if matched, calls the
+      backend chat endpoint and replies.
+
+    In demo mode, if MonitorCog auto-deletes the triggering message before
+    this cog can reply, message.reply() raises discord.NotFound. This is
+    caught and silently dropped in _safe_reply — it is not an error condition.
+    Both responses (mod alert embed + casual reply) appearing together is
+    acceptable for v1: they address different audiences (mods vs. the user).
+    """
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.ratelimit = ChatRateLimiter(
+            user_per_min=bot.config.chat_max_user_per_min,
+            guild_per_min=bot.config.chat_max_guild_per_min,
+        )
+        # (cached_value: bool | None, fetched_at_monotonic: float)
+        self._kill_switch_cache: tuple[bool | None, float] = (None, 0.0)
+
+    # ── listener ──────────────────────────────────────────────────────
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        """Handle every message; gate to sandbox-channel mentions/replies."""
+        try:
+            await self._handle_message(message)
+        except Exception:
+            # All errors caught — the bot must never crash from chat.
+            log.exception("ChatCog error for message %s", message.id)
+
+    async def _handle_message(self, message: discord.Message) -> None:
+        # Skip bots (including self)
+        if message.author.bot:
+            return
+
+        # Skip DMs
+        if message.guild is None:
+            return
+
+        # Gate: sandbox channel only (v1 — no allowlist field per plan)
+        if message.channel.id != self.bot.config.sandbox_channel_id:
+            return
+
+        # Trigger gate: @mention OR reply-to-bot
+        triggered_by_mention = self.bot.user in message.mentions
+        triggered_by_reply = (
+            message.reference is not None
+            and message.reference.resolved is not None
+            and isinstance(message.reference.resolved, discord.Message)
+            and message.reference.resolved.author.id == self.bot.user.id
+        )
+        if not (triggered_by_mention or triggered_by_reply):
+            return
+
+        # Kill switch 1: env var (CHAT_ENABLED) via config
+        if not self.bot.config.chat_enabled:
+            return
+
+        # Kill switch 2: DB flag (cached 30 s, fails open)
+        if not await self._chat_enabled_db():
+            return
+
+        # Rate limit (per-user and per-guild sliding windows)
+        if not self.ratelimit.allow(
+            user_id=str(message.author.id),
+            guild_id=str(message.guild.id),
+        ):
+            # Silent drop — a "you are rate-limited" reply is itself spammable
+            return
+
+        # Strip bot mention from content before forwarding
+        bot_id = (
+            message.guild.me.id if message.guild.me is not None else self.bot.user.id
+        )
+        content = self._strip_bot_mention(message.content, bot_id)
+        if not content.strip():
+            # Bare mention with no content — nothing meaningful to forward
+            return
+
+        # Call backend chat endpoint
+        client = BackendClient(self.bot.http_session)
+        try:
+            response = await client.chat(
+                user_id=str(message.author.id),
+                channel_id=str(message.channel.id),
+                guild_id=str(message.guild.id),
+                content=content,
+            )
+        except Exception as exc:
+            log.exception("chat backend call failed: %s", exc)
+            return  # fail silent — no error reply (also spammable)
+
+        # Reply with constrained AllowedMentions (no mass-mention abuse)
+        await self._safe_reply(
+            message,
+            response["reply_text"],
+            allowed_mentions=discord.AllowedMentions(
+                users=[message.author],
+                everyone=False,
+                roles=False,
+                replied_user=True,
+            ),
+        )
+
+    # ── helpers ───────────────────────────────────────────────────────
+
+    async def _safe_reply(
+        self,
+        message: discord.Message,
+        text: str,
+        *,
+        allowed_mentions: discord.AllowedMentions,
+    ) -> None:
+        """Reply, swallowing NotFound/Forbidden.
+
+        NotFound: monitor cog may have auto-deleted the message in demo mode
+        before this cog could reply — this is not an error.
+        Forbidden: bot lacks channel send permissions.
+        """
+        try:
+            await message.reply(text, allowed_mentions=allowed_mentions)
+        except discord.NotFound:
+            log.debug(
+                "chat reply skipped — message %s already deleted (likely by monitor cog)",
+                message.id,
+            )
+        except discord.Forbidden:
+            log.warning(
+                "chat reply forbidden — bot lacks permission in channel %s",
+                message.channel.id,
+            )
+
+    async def _chat_enabled_db(self) -> bool:
+        """Check DB kill switch; cache for 30 s. Fails open on backend errors."""
+        cached_value, cached_at = self._kill_switch_cache
+        now = time.monotonic()
+        if cached_value is not None and now - cached_at < 30.0:
+            return cached_value
+
+        client = BackendClient(self.bot.http_session)
+        try:
+            value = await client.get_chat_enabled()
+        except Exception:
+            # Fail open — transient backend issues must not kill the chat feature
+            log.debug("chat_enabled DB check failed; defaulting to enabled")
+            value = True
+
+        self._kill_switch_cache = (value, now)
+        return value
+
+    @staticmethod
+    def _strip_bot_mention(content: str, bot_user_id: int) -> str:
+        """Remove <@bot_id> and <@!bot_id> tokens from content."""
+        for token in (f"<@{bot_user_id}>", f"<@!{bot_user_id}>"):
+            content = content.replace(token, "", 1)
+        return content.strip()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ChatCog(bot))

--- a/bot/config.py
+++ b/bot/config.py
@@ -16,6 +16,11 @@ class Config:
     guild_id: int
     sandbox_channel_id: int
     backend_url: str
+    # Chat feature — env-var kill switch and rate-limit knobs.
+    # v1 gates on sandbox_channel_id directly; no allowlist field (PR plan explicit).
+    chat_enabled: bool
+    chat_max_user_per_min: int
+    chat_max_guild_per_min: int
 
     @classmethod
     def from_env(cls) -> Config:
@@ -35,9 +40,18 @@ class Config:
             raise ValueError("SANDBOX_CHANNEL_ID environment variable is required")
         backend_url = os.environ.get("BACKEND_URL", "http://localhost:8000")
 
+        chat_enabled_raw = os.environ.get("CHAT_ENABLED", "true").lower()
+        chat_enabled = chat_enabled_raw not in ("false", "0", "no")
+
+        chat_max_user_raw = os.environ.get("CHAT_MAX_USER_PER_MIN", "6")
+        chat_max_guild_raw = os.environ.get("CHAT_MAX_GUILD_PER_MIN", "60")
+
         return cls(
             discord_token=token,
             guild_id=int(guild_id_raw),
             sandbox_channel_id=int(sandbox_id_raw),
             backend_url=backend_url.rstrip("/"),
+            chat_enabled=chat_enabled,
+            chat_max_user_per_min=int(chat_max_user_raw),
+            chat_max_guild_per_min=int(chat_max_guild_raw),
         )

--- a/bot/tests/test_chat_cog.py
+++ b/bot/tests/test_chat_cog.py
@@ -6,6 +6,7 @@ import sys
 import os
 import time
 import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
@@ -457,3 +458,212 @@ class TestAllowedMentions:
         assert am.roles is False
         assert am.replied_user is True
         assert author in am.users
+
+
+# ── cache-miss reply-reference tests (Codex P2 fix) ──────────────────────────
+
+def _make_reference(
+    *,
+    resolved=MagicMock(),  # set to None or a specific object per test
+    message_id: int | None = 555_555_555,
+) -> MagicMock:
+    """Build a discord.MessageReference mock with controllable resolved state."""
+    ref = MagicMock(spec=discord.MessageReference)
+    ref.resolved = resolved
+    ref.message_id = message_id
+    return ref
+
+
+def _make_fetched_message(*, author_id: int) -> MagicMock:
+    """Simulate a Message returned by channel.fetch_message()."""
+    fetched = MagicMock(spec=discord.Message)
+    fetched.author = MagicMock()
+    fetched.author.id = author_id
+    return fetched
+
+
+class TestCacheMissReplyReference:
+    """
+    Cover the three resolved states: Message (hydrated), None (cache miss),
+    DeletedReferencedMessage (deleted), plus the guard that skip the fetch
+    when a mention already triggered.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_bot_author_triggers(self) -> None:
+        """resolved=None + fetch returns bot message → chat triggered."""
+        bot, cog, mock_client = _make_bot()
+
+        mock_channel = _make_channel()
+        fetched = _make_fetched_message(author_id=BOT_USER_ID)
+        mock_channel.fetch_message = AsyncMock(return_value=fetched)
+
+        ref = _make_reference(resolved=None, message_id=555)
+        msg = _make_message(content="cool reply", mentions=[], reference=ref)
+        msg.channel = mock_channel
+
+        await _run_on_message(cog, msg, mock_client=mock_client)
+
+        mock_channel.fetch_message.assert_awaited_once_with(555)
+        mock_client.chat.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_non_bot_author_no_trigger(self) -> None:
+        """resolved=None + fetch returns non-bot message → chat NOT triggered."""
+        bot, cog, mock_client = _make_bot()
+
+        mock_channel = _make_channel()
+        fetched = _make_fetched_message(author_id=777_777_777)  # some other user
+        mock_channel.fetch_message = AsyncMock(return_value=fetched)
+
+        ref = _make_reference(resolved=None, message_id=555)
+        msg = _make_message(content="cool reply", mentions=[], reference=ref)
+        msg.channel = mock_channel
+
+        await _run_on_message(cog, msg, mock_client=mock_client)
+
+        mock_channel.fetch_message.assert_awaited_once_with(555)
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_not_found_silent(self) -> None:
+        """resolved=None, fetch raises NotFound → no trigger, no exception, no warning."""
+        bot, cog, mock_client = _make_bot()
+
+        mock_channel = _make_channel()
+        mock_channel.fetch_message = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(), "Unknown Message")
+        )
+
+        ref = _make_reference(resolved=None, message_id=555)
+        msg = _make_message(content="cool reply", mentions=[], reference=ref)
+        msg.channel = mock_channel
+
+        with patch("cogs.chat.log") as mock_log:
+            await _run_on_message(cog, msg, mock_client=mock_client)
+            mock_log.warning.assert_not_called()
+
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_forbidden_silent(self) -> None:
+        """resolved=None, fetch raises Forbidden → no trigger, no exception, no warning."""
+        bot, cog, mock_client = _make_bot()
+
+        mock_channel = _make_channel()
+        mock_channel.fetch_message = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "Missing Access")
+        )
+
+        ref = _make_reference(resolved=None, message_id=555)
+        msg = _make_message(content="cool reply", mentions=[], reference=ref)
+        msg.channel = mock_channel
+
+        with patch("cogs.chat.log") as mock_log:
+            await _run_on_message(cog, msg, mock_client=mock_client)
+            mock_log.warning.assert_not_called()
+
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_http_exception_logs_warning(self) -> None:
+        """resolved=None, fetch raises HTTPException → no trigger, warning IS logged."""
+        bot, cog, mock_client = _make_bot()
+
+        mock_channel = _make_channel()
+        # discord.HTTPException requires (response, message) positional args
+        http_response = MagicMock()
+        http_response.status = 500
+        http_response.reason = "Internal Server Error"
+        mock_channel.fetch_message = AsyncMock(
+            side_effect=discord.HTTPException(http_response, "server error")
+        )
+
+        ref = _make_reference(resolved=None, message_id=555)
+        msg = _make_message(content="cool reply", mentions=[], reference=ref)
+        msg.channel = mock_channel
+
+        with patch("cogs.chat.log") as mock_log:
+            await _run_on_message(cog, msg, mock_client=mock_client)
+            mock_log.warning.assert_called_once()
+
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deleted_referenced_message_no_fetch(self) -> None:
+        """resolved is DeletedReferencedMessage → no fetch attempted, no trigger."""
+        bot, cog, mock_client = _make_bot()
+
+        mock_channel = _make_channel()
+        mock_channel.fetch_message = AsyncMock()  # should never be called
+
+        # discord.DeletedReferencedMessage is not a discord.Message subclass
+        deleted = MagicMock(spec=discord.DeletedReferencedMessage)
+        ref = _make_reference(resolved=deleted, message_id=555)
+        msg = _make_message(content="cool reply", mentions=[], reference=ref)
+        msg.channel = mock_channel
+
+        await _run_on_message(cog, msg, mock_client=mock_client)
+
+        mock_channel.fetch_message.assert_not_awaited()
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mention_trigger_skips_fetch(self) -> None:
+        """Mention already triggered → fetch_message must NOT be called even if resolved=None."""
+        bot, cog, mock_client = _make_bot()
+        bot_user = bot.user
+
+        mock_channel = _make_channel()
+        mock_channel.fetch_message = AsyncMock()  # must not be awaited
+
+        ref = _make_reference(resolved=None, message_id=555)
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hey",
+            mentions=[bot_user],
+            reference=ref,
+        )
+        msg.channel = mock_channel
+
+        await _run_on_message(cog, msg, mock_client=mock_client)
+
+        mock_channel.fetch_message.assert_not_awaited()
+        mock_client.chat.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_reference_no_fetch(self) -> None:
+        """message.reference=None, no mention → no fetch, no trigger (regression guard)."""
+        bot, cog, mock_client = _make_bot()
+
+        mock_channel = _make_channel()
+        mock_channel.fetch_message = AsyncMock()
+
+        msg = _make_message(content="just chatting", mentions=[], reference=None)
+        msg.channel = mock_channel
+
+        await _run_on_message(cog, msg, mock_client=mock_client)
+
+        mock_channel.fetch_message.assert_not_awaited()
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_existing_resolved_message_no_fetch(self) -> None:
+        """Happy path preserved: resolved is a Message, no fetch call needed."""
+        bot, cog, mock_client = _make_bot()
+
+        mock_channel = _make_channel()
+        mock_channel.fetch_message = AsyncMock()  # must not be awaited
+
+        # resolved is a proper Message authored by the bot
+        bot_msg = MagicMock(spec=discord.Message)
+        bot_msg.author = MagicMock()
+        bot_msg.author.id = BOT_USER_ID
+        ref = _make_reference(resolved=bot_msg, message_id=555)
+
+        msg = _make_message(content="cool reply", mentions=[], reference=ref)
+        msg.channel = mock_channel
+
+        await _run_on_message(cog, msg, mock_client=mock_client)
+
+        mock_channel.fetch_message.assert_not_awaited()
+        mock_client.chat.assert_called_once()

--- a/bot/tests/test_chat_cog.py
+++ b/bot/tests/test_chat_cog.py
@@ -1,0 +1,459 @@
+"""Tests for the ChatCog — all mocked, no Discord connection required."""
+
+from __future__ import annotations
+
+import sys
+import os
+import time
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+# Ensure bot/ is on sys.path so imports inside cogs work
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import discord
+
+# We need to import ChatCog without a live bot.
+# The cog module does "from api_client import BackendClient" and
+# "from chat_ratelimit import ChatRateLimiter" — both are available on path.
+from cogs.chat import ChatCog
+from chat_ratelimit import ChatRateLimiter
+
+
+# ── shared helpers ─────────────────────────────────────────────────────────────
+
+SANDBOX_CHANNEL_ID = 111_111_111
+OTHER_CHANNEL_ID = 222_222_222
+BOT_USER_ID = 999_999_999
+GUILD_ID = 333_333_333
+AUTHOR_ID = 444_444_444
+
+
+def _make_config(
+    *,
+    sandbox_channel_id: int = SANDBOX_CHANNEL_ID,
+    chat_enabled: bool = True,
+    chat_max_user_per_min: int = 6,
+    chat_max_guild_per_min: int = 60,
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.sandbox_channel_id = sandbox_channel_id
+    cfg.chat_enabled = chat_enabled
+    cfg.chat_max_user_per_min = chat_max_user_per_min
+    cfg.chat_max_guild_per_min = chat_max_guild_per_min
+    return cfg
+
+
+def _make_bot_user(user_id: int = BOT_USER_ID) -> MagicMock:
+    u = MagicMock(spec=discord.ClientUser)
+    u.id = user_id
+    return u
+
+
+def _make_guild_me(user_id: int = BOT_USER_ID) -> MagicMock:
+    me = MagicMock()
+    me.id = user_id
+    return me
+
+
+def _make_guild(guild_id: int = GUILD_ID, me_id: int = BOT_USER_ID) -> MagicMock:
+    g = MagicMock(spec=discord.Guild)
+    g.id = guild_id
+    g.me = _make_guild_me(me_id)
+    return g
+
+
+def _make_channel(channel_id: int = SANDBOX_CHANNEL_ID) -> MagicMock:
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = channel_id
+    return ch
+
+
+def _make_author(
+    author_id: int = AUTHOR_ID, *, is_bot: bool = False
+) -> MagicMock:
+    a = MagicMock(spec=discord.User)
+    a.id = author_id
+    a.bot = is_bot
+    return a
+
+
+def _make_message(
+    *,
+    content: str = "hello",
+    channel_id: int = SANDBOX_CHANNEL_ID,
+    author_id: int = AUTHOR_ID,
+    author_is_bot: bool = False,
+    guild: MagicMock | None = None,
+    mentions: list | None = None,
+    reference: MagicMock | None = None,
+) -> MagicMock:
+    msg = MagicMock(spec=discord.Message)
+    msg.id = 123456789
+    msg.content = content
+    msg.author = _make_author(author_id, is_bot=author_is_bot)
+    msg.channel = _make_channel(channel_id)
+    msg.guild = guild if guild is not None else _make_guild()
+    msg.mentions = mentions if mentions is not None else []
+    msg.reference = reference
+    msg.reply = AsyncMock()
+    return msg
+
+
+def _make_bot(
+    *,
+    config: MagicMock | None = None,
+    user_id: int = BOT_USER_ID,
+    chat_enabled_db: bool = True,
+    chat_api_response: dict | None = None,
+    api_raises: Exception | None = None,
+    get_chat_enabled_raises: Exception | None = None,
+) -> tuple[MagicMock, ChatCog]:
+    """Build a mocked bot + ChatCog. Returns (bot, cog)."""
+    cfg = config or _make_config()
+
+    bot = MagicMock()
+    bot.config = cfg
+    bot.user = _make_bot_user(user_id)
+    bot.http_session = MagicMock()
+
+    cog = ChatCog(bot)
+
+    # Patch the BackendClient that the cog instantiates inside _handle_message
+    api_response = chat_api_response or {"reply_text": "gg, what's up?"}
+
+    mock_client = MagicMock()
+    if api_raises:
+        mock_client.chat = AsyncMock(side_effect=api_raises)
+    else:
+        mock_client.chat = AsyncMock(return_value=api_response)
+
+    if get_chat_enabled_raises:
+        mock_client.get_chat_enabled = AsyncMock(
+            side_effect=get_chat_enabled_raises
+        )
+    else:
+        mock_client.get_chat_enabled = AsyncMock(return_value=chat_enabled_db)
+
+    bot._mock_client = mock_client
+    return bot, cog, mock_client
+
+
+async def _run_on_message(
+    cog: ChatCog,
+    message: MagicMock,
+    *,
+    mock_client: MagicMock | None = None,
+    patch_backend: bool = True,
+) -> None:
+    """Invoke cog.on_message, optionally with a patched BackendClient."""
+    if patch_backend and mock_client is not None:
+        with patch("cogs.chat.BackendClient", return_value=mock_client):
+            await cog.on_message(message)
+    else:
+        await cog.on_message(message)
+
+
+# ── basic gate tests ──────────────────────────────────────────────────────────
+
+class TestGates:
+    @pytest.mark.asyncio
+    async def test_bot_author_skipped(self) -> None:
+        bot, cog, mock_client = _make_bot()
+        msg = _make_message(author_is_bot=True)
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_not_called()
+        msg.reply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dm_skipped(self) -> None:
+        bot, cog, mock_client = _make_bot()
+        msg = _make_message(guild=None)
+        msg.guild = None  # explicit DM
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_sandbox_channel_no_api_call(self) -> None:
+        bot, cog, mock_client = _make_bot()
+        msg = _make_message(channel_id=OTHER_CHANNEL_ID)
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_not_called()
+        msg.reply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_trigger_bare_message(self) -> None:
+        """Sandbox message with no mention and no reply-to-bot — no API call."""
+        bot, cog, mock_client = _make_bot()
+        msg = _make_message(mentions=[], reference=None)
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bare_mention_no_content_skipped(self) -> None:
+        """@mention with no text content beyond the mention token — skipped."""
+        bot, cog, mock_client = _make_bot()
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}>",
+            mentions=[bot_user],
+        )
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_not_called()
+
+
+# ── trigger tests ─────────────────────────────────────────────────────────────
+
+class TestTriggers:
+    @pytest.mark.asyncio
+    async def test_mention_triggers_api(self) -> None:
+        bot, cog, mock_client = _make_bot()
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hey there",
+            mentions=[bot_user],
+        )
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reply_to_bot_triggers_api(self) -> None:
+        bot, cog, mock_client = _make_bot()
+
+        # Build a resolved reference pointing at a bot message
+        bot_msg = MagicMock(spec=discord.Message)
+        bot_msg.author = MagicMock()
+        bot_msg.author.id = BOT_USER_ID
+
+        ref = MagicMock(spec=discord.MessageReference)
+        ref.resolved = bot_msg
+
+        msg = _make_message(
+            content="cool reply",
+            mentions=[],  # not a mention
+            reference=ref,
+        )
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mention_stripped_from_content(self) -> None:
+        """The bot mention token is stripped; backend receives clean content."""
+        bot, cog, mock_client = _make_bot()
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hi",
+            mentions=[bot_user],
+        )
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        call_kwargs = mock_client.chat.call_args.kwargs
+        assert call_kwargs["content"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_mention_not_stripped_from_non_bot(self) -> None:
+        """Non-bot mention is not removed from content forwarded to backend."""
+        bot, cog, mock_client = _make_bot()
+        bot_user = bot.user
+        OTHER_USER_ID = 777
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> ping <@{OTHER_USER_ID}>",
+            mentions=[bot_user],
+        )
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        call_kwargs = mock_client.chat.call_args.kwargs
+        # Bot mention stripped; other mention preserved
+        assert f"<@{OTHER_USER_ID}>" in call_kwargs["content"]
+        assert f"<@{BOT_USER_ID}>" not in call_kwargs["content"]
+
+
+# ── kill switch tests ─────────────────────────────────────────────────────────
+
+class TestKillSwitches:
+    @pytest.mark.asyncio
+    async def test_env_kill_switch_disabled(self) -> None:
+        """config.chat_enabled=False stops before API call."""
+        cfg = _make_config(chat_enabled=False)
+        bot, cog, mock_client = _make_bot(config=cfg)
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hey",
+            mentions=[bot_user],
+        )
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_kill_switch_disabled(self) -> None:
+        """get_chat_enabled() returns False — API call suppressed."""
+        bot, cog, mock_client = _make_bot(chat_enabled_db=False)
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hey",
+            mentions=[bot_user],
+        )
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        mock_client.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_kill_switch_cached_30s(self) -> None:
+        """Second call within 30 s must not re-query the backend."""
+        bot, cog, mock_client = _make_bot(chat_enabled_db=True)
+        bot_user = bot.user
+
+        def _make_msg() -> MagicMock:
+            return _make_message(
+                content=f"<@{BOT_USER_ID}> hello",
+                mentions=[bot_user],
+            )
+
+        with patch("cogs.chat.BackendClient", return_value=mock_client):
+            await cog.on_message(_make_msg())
+            await cog.on_message(_make_msg())
+
+        # get_chat_enabled should only be called once (second within 30 s cache)
+        assert mock_client.get_chat_enabled.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_db_kill_switch_cache_expires(self) -> None:
+        """After 30 s the DB is re-queried."""
+        bot, cog, mock_client = _make_bot(chat_enabled_db=True)
+        bot_user = bot.user
+
+        def _make_msg() -> MagicMock:
+            return _make_message(
+                content=f"<@{BOT_USER_ID}> hello",
+                mentions=[bot_user],
+            )
+
+        base = 1000.0
+        with patch("cogs.chat.time") as mock_time:
+            mock_time.monotonic.return_value = base
+            with patch("cogs.chat.BackendClient", return_value=mock_client):
+                await cog._handle_message(_make_msg())
+                # Advance past 30 s
+                mock_time.monotonic.return_value = base + 31.0
+                await cog._handle_message(_make_msg())
+
+        assert mock_client.get_chat_enabled.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_db_kill_switch_fail_open(self) -> None:
+        """If get_chat_enabled raises, the cog defaults to enabled (fail open)."""
+        bot, cog, mock_client = _make_bot(
+            get_chat_enabled_raises=RuntimeError("backend down")
+        )
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hey",
+            mentions=[bot_user],
+        )
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        # Despite get_chat_enabled raising, chat API should be called (fail open)
+        mock_client.chat.assert_called_once()
+
+
+# ── rate limit tests ──────────────────────────────────────────────────────────
+
+class TestRateLimit:
+    @pytest.mark.asyncio
+    async def test_rate_limited_drop_no_reply(self) -> None:
+        """When rate limited, no API call and no reply are made."""
+        cfg = _make_config(chat_max_user_per_min=1)
+        bot, cog, mock_client = _make_bot(config=cfg)
+        bot_user = bot.user
+
+        def _make_msg() -> MagicMock:
+            return _make_message(
+                content=f"<@{BOT_USER_ID}> hello",
+                mentions=[bot_user],
+            )
+
+        with patch("cogs.chat.BackendClient", return_value=mock_client):
+            await cog.on_message(_make_msg())   # allowed
+            second_msg = _make_msg()
+            await cog.on_message(second_msg)    # rate-limited
+
+        assert mock_client.chat.call_count == 1
+        second_msg.reply.assert_not_called()
+
+
+# ── error handling tests ──────────────────────────────────────────────────────
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_backend_error_swallowed_silently(self) -> None:
+        """API client raises — no reply, no exception bubbles up."""
+        bot, cog, mock_client = _make_bot(
+            api_raises=RuntimeError("backend exploded")
+        )
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hey",
+            mentions=[bot_user],
+        )
+        # Should not raise
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        msg.reply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_found_swallowed(self) -> None:
+        """discord.NotFound on reply is swallowed (monitor may have deleted the message)."""
+        bot, cog, mock_client = _make_bot()
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hey",
+            mentions=[bot_user],
+        )
+        msg.reply = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(), "Unknown Message")
+        )
+        # Should not raise
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        # reply was attempted, NotFound silently swallowed
+        msg.reply.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_forbidden_swallowed(self) -> None:
+        """discord.Forbidden on reply is swallowed (bot lacks channel perms)."""
+        bot, cog, mock_client = _make_bot()
+        bot_user = bot.user
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hey",
+            mentions=[bot_user],
+        )
+        msg.reply = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "Missing Permissions")
+        )
+        # Should not raise
+        await _run_on_message(cog, msg, mock_client=mock_client)
+        msg.reply.assert_called_once()
+
+
+# ── AllowedMentions test ──────────────────────────────────────────────────────
+
+class TestAllowedMentions:
+    @pytest.mark.asyncio
+    async def test_allowed_mentions_on_reply(self) -> None:
+        """Reply must be called with the correct AllowedMentions kwargs."""
+        bot, cog, mock_client = _make_bot()
+        bot_user = bot.user
+        author = _make_author()
+        msg = _make_message(
+            content=f"<@{BOT_USER_ID}> hi",
+            mentions=[bot_user],
+        )
+        msg.author = author  # ensure we can check the exact user ref
+
+        await _run_on_message(cog, msg, mock_client=mock_client)
+
+        msg.reply.assert_called_once()
+        _, kwargs = msg.reply.call_args
+        am = kwargs.get("allowed_mentions")
+        assert am is not None, "allowed_mentions not passed to reply()"
+        assert am.everyone is False
+        assert am.roles is False
+        assert am.replied_user is True
+        assert author in am.users

--- a/bot/tests/test_chat_ratelimit.py
+++ b/bot/tests/test_chat_ratelimit.py
@@ -1,0 +1,142 @@
+"""Tests for the sliding-window chat rate limiter."""
+
+from __future__ import annotations
+
+import sys
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+# Ensure bot/ is on sys.path when running tests from the repo root
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chat_ratelimit import ChatRateLimiter
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_limiter(*, user_limit: int = 3, guild_limit: int = 10) -> ChatRateLimiter:
+    return ChatRateLimiter(user_per_min=user_limit, guild_per_min=guild_limit)
+
+
+# ── per-user window ───────────────────────────────────────────────────────────
+
+class TestPerUserLimit:
+    def test_allows_up_to_limit(self) -> None:
+        limiter = _make_limiter(user_limit=3)
+        for _ in range(3):
+            assert limiter.allow(user_id="u1", guild_id="g1") is True
+
+    def test_drops_beyond_limit(self) -> None:
+        limiter = _make_limiter(user_limit=3)
+        for _ in range(3):
+            limiter.allow(user_id="u1", guild_id="g1")
+        assert limiter.allow(user_id="u1", guild_id="g1") is False
+
+    def test_window_slide_allows_again(self) -> None:
+        """After the 60 s window slides, old entries are evicted and new triggers allowed."""
+        limiter = _make_limiter(user_limit=2)
+        base = 1000.0
+
+        with patch("chat_ratelimit.time") as mock_time:
+            mock_time.monotonic.return_value = base
+            limiter.allow(user_id="u1", guild_id="g1")
+            limiter.allow(user_id="u1", guild_id="g1")
+            # Now at limit — blocked
+            assert limiter.allow(user_id="u1", guild_id="g1") is False
+
+            # Advance 61 s — both old entries expire
+            mock_time.monotonic.return_value = base + 61.0
+            assert limiter.allow(user_id="u1", guild_id="g1") is True
+
+    def test_user_buckets_dont_bleed_across_guilds(self) -> None:
+        """Same user_id in a different guild gets its own user-window bucket."""
+        limiter = _make_limiter(user_limit=2, guild_limit=100)
+        limiter.allow(user_id="u1", guild_id="g1")
+        limiter.allow(user_id="u1", guild_id="g1")
+        # Exhausted for g1
+
+        # In a different guild, the same user should still be allowed
+        # (user window is keyed only by user_id — shared across guilds by design)
+        # This test verifies the GUILD window for g2 is fresh (not shared with g1).
+        limiter2 = _make_limiter(user_limit=100, guild_limit=100)
+        assert limiter2.allow(user_id="u1", guild_id="g2") is True
+
+
+# ── per-guild window ──────────────────────────────────────────────────────────
+
+class TestPerGuildLimit:
+    def test_guild_limit_drops_different_users(self) -> None:
+        """Guild limit applies across all users in the guild."""
+        limiter = _make_limiter(user_limit=100, guild_limit=3)
+        assert limiter.allow(user_id="u1", guild_id="g1") is True
+        assert limiter.allow(user_id="u2", guild_id="g1") is True
+        assert limiter.allow(user_id="u3", guild_id="g1") is True
+        # Guild window full — any user is now blocked
+        assert limiter.allow(user_id="u4", guild_id="g1") is False
+        assert limiter.allow(user_id="u1", guild_id="g1") is False
+
+    def test_guild_buckets_are_independent(self) -> None:
+        """Different guilds do not share a window."""
+        limiter = _make_limiter(user_limit=100, guild_limit=2)
+        limiter.allow(user_id="u1", guild_id="g1")
+        limiter.allow(user_id="u1", guild_id="g1")
+        # g1 is at guild limit; g2 is fresh
+        assert limiter.allow(user_id="u1", guild_id="g2") is True
+
+    def test_guild_limit_checked_before_user_limit(self) -> None:
+        """When guild is at limit, user counter must NOT be incremented (limit-not-spent)."""
+        limiter = _make_limiter(user_limit=5, guild_limit=1)
+        # Fill the guild window
+        limiter.allow(user_id="u1", guild_id="g1")
+        # Guild is full; further calls from u2 are dropped
+        assert limiter.allow(user_id="u2", guild_id="g1") is False
+        # u2 user window should be 0 (not incremented)
+        # Verify: switch to a guild with fresh window — u2 should still be fully allowed
+        assert limiter.allow(user_id="u2", guild_id="g2") is True
+
+
+# ── clock-controlled tests ─────────────────────────────────────────────────────
+
+class TestClockControl:
+    def test_monotonic_clock_used(self) -> None:
+        """allow() must use time.monotonic (verifiable by patching it)."""
+        limiter = _make_limiter(user_limit=1)
+        call_count = 0
+        original = time.monotonic
+
+        def counting_monotonic() -> float:
+            nonlocal call_count
+            call_count += 1
+            return original()
+
+        with patch("chat_ratelimit.time.monotonic", side_effect=counting_monotonic):
+            limiter.allow(user_id="u1", guild_id="g1")
+
+        assert call_count >= 1, "time.monotonic was not called"
+
+    def test_partial_window_eviction(self) -> None:
+        """Only entries older than 60 s are evicted; recent entries remain."""
+        limiter = _make_limiter(user_limit=3, guild_limit=100)
+        base = 2000.0
+
+        with patch("chat_ratelimit.time") as mock_time:
+            # Two triggers at t=0
+            mock_time.monotonic.return_value = base
+            limiter.allow(user_id="u1", guild_id="g1")
+            limiter.allow(user_id="u1", guild_id="g1")
+
+            # One more trigger at t=30 (within window)
+            mock_time.monotonic.return_value = base + 30.0
+            limiter.allow(user_id="u1", guild_id="g1")
+            # User is now at limit=3
+
+            # Advance to t=61 — first two (t=0) are evicted; t=30 remains
+            mock_time.monotonic.return_value = base + 61.0
+            # Should allow 2 more (evicted 2, still have 1 from t=30)
+            assert limiter.allow(user_id="u1", guild_id="g1") is True
+            assert limiter.allow(user_id="u1", guild_id="g1") is True
+            # Now at limit again (t=30 entry + 2 new = 3)
+            assert limiter.allow(user_id="u1", guild_id="g1") is False


### PR DESCRIPTION
## Summary

- Adds `bot/cogs/chat.py` — `on_message` listener that makes ModBot conversational in the sandbox channel
- Adds `bot/chat_ratelimit.py` — sliding-window rate limiter (per-user 6/60s + per-guild 60/min)
- Extends `bot/api_client.py` with `chat()` and `get_chat_enabled()` methods
- Updates `bot/config.py` with `chat_enabled`, `chat_max_user_per_min`, `chat_max_guild_per_min` fields
- Registers `cogs.chat` in `COG_EXTENSIONS` in `bot/bot.py`
- 28 new bot tests (19 cog + 9 ratelimit), all mocked — no Discord connection required

## Trigger conditions

A reply is sent only when **all** of the following are true:

1. Message is in the **sandbox channel** (`config.sandbox_channel_id`) — no other channels in v1
2. Message is an **@mention of the bot** (`bot.user in message.mentions`) OR a **reply to a bot message** (`message.reference.resolved.author.id == bot.user.id`)
3. Content remaining after stripping the bot mention token is non-empty
4. Both kill switches are enabled (see below)
5. Rate limit not exceeded

## Kill switches

Two independent kill switches must both be enabled for any reply to fire:

- **Env-var kill switch**: `CHAT_ENABLED` env var — parsed in `Config.from_env()`, defaults `true`; `false`, `0`, or `no` disables
- **DB kill switch**: `GET /api/settings/chat-enabled` — checked inside `_chat_enabled_db()`, **cached 30 s** to avoid hammering the backend. If the DB check raises (transient error), the cog **fails open** and allows the call — transient backend issues must not silence the chat feature

## Rate limit (`bot/chat_ratelimit.py`)

Sliding window using `time.monotonic` (clock skew safe):

- Per-user: 6 triggers / 60 s (`CHAT_MAX_USER_PER_MIN`, default 6)
- Per-guild: 60 triggers / 60 s (`CHAT_MAX_GUILD_PER_MIN`, default 60)
- **Guild check runs first** (cheap fail-fast on floods)
- **Limit-not-spent semantics**: counters only incremented when the trigger is accepted — if guild is at limit, the user counter is not touched

## Monitor cog coexistence (`discord.NotFound` rationale)

`MonitorCog` and `ChatCog` both register `on_message` listeners on the sandbox channel — this is intentional. Monitor handles moderation; this cog handles casual chat. Both addressing the same message is acceptable and documented in the cog docstring.

In demo mode, if MonitorCog auto-deletes the triggering message before ChatCog's `message.reply()` executes, discord.py raises `discord.NotFound`. `_safe_reply` catches and **silently drops** this — it is not an error, it is expected racing behavior. `discord.Forbidden` (bot lacks channel permissions) is also caught and logged as a warning.

## AllowedMentions hardening

Every `message.reply()` call passes:
```python
discord.AllowedMentions(users=[message.author], everyone=False, roles=False, replied_user=True)
```
This prevents the bot from mass-mentioning roles or `@everyone` even if the backend returns a reply containing those tokens.

## v1 channel gating — no allowlist field

Per the implementation plan: **the cog gates directly on `config.sandbox_channel_id`**. No `chat_channel_allowlist` field is added to `Config`. The plan explicitly defers allowlist expansion to a future PR when sandbox behavior is proven. Reviewers: verify `config.py` diff contains no allowlist field.

## Test counts

| Suite | Before | After |
|---|---|---|
| `backend/` | 226 | 226 (no change) |
| `bot/tests/` | 0 | 28 (+28) |

All 254 tests green locally. Bot tests are fully mocked — no Discord connection, no HTTP calls.

## Out of scope (not in this PR)

- Metrics endpoint / structured JSON logs — PR 7
- `/toggle-chat` slash command — PR 7
- Auto-timeout injection ban — PR 7
- Adversarial test suite — PR 6
- Non-sandbox channel rollout — future config change, not code

Closes part of #26