### PR TITLE
docs: scope Required env vars heading to chat feature (missed in #34 merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ The feature was designed against OWASP LLM Top 10 2025 (LLM01 Prompt Injection, 
 - **Mention scope**: every reply uses `discord.AllowedMentions(users=[author], everyone=False, roles=False)`.
 - **Adversarial CI**: 15-case mocked test suite in `backend/tests/test_chat_adversarial.py`.
 
-### Required env vars
+### Required env vars (chat feature)
 
-Three vars **must** be set to real values before running (see `.env.example` for full comments):
+These are **in addition to** the base vars from the Quick Start (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `DISCORD_TOKEN`, `DISCORD_GUILD_ID`, `SANDBOX_CHANNEL_ID`) — the chat feature does not run without all of them. Three vars specific to chat **must** be set to real values before running (see `.env.example` for full comments):
 
 | Variable | Purpose |
 |---|---|


### PR DESCRIPTION
## Summary

Follow-up to PR #34. Commit `b8b0609` (the scope-fix for the \"Required env vars\" heading) was pushed to the `docs/readme-modbot-chat-section` branch but did not land in the merge — the merge picked up the branch at `e55ad93`. This one-commit PR brings the missed fix onto `main`.

## The fix

In the new Conversational Chat section, the heading `### Required env vars` read as top-level scope when embedded in a subsection. A reader scanning the README could reasonably conclude the three listed chat vars were the only required vars for running the project, missing the five base vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `DISCORD_TOKEN`, `DISCORD_GUILD_ID`, `SANDBOX_CHANNEL_ID`).

### Changes

- Heading: `### Required env vars` → `### Required env vars (chat feature)`
- Leading sentence added: explicitly restates the five base vars from the Quick Start and notes that chat does not run without all of them

## Test plan

Docs-only; no code touched. The previous 350-test suite is unaffected.