### PR TITLE
Portal polish + simplification pass

### DIFF
--- a/backend/providers/anthropic_provider.py
+++ b/backend/providers/anthropic_provider.py
@@ -16,6 +16,17 @@ class AnthropicProvider(BaseLLMProvider):
         self._client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
         self._model = settings.ANTHROPIC_MODEL
 
+    def _to_response(self, resp) -> ProviderResponse:
+        return ProviderResponse(
+            text=resp.content[0].text,
+            provider_name="anthropic",
+            model=self._model,
+            usage={
+                "input_tokens": resp.usage.input_tokens,
+                "output_tokens": resp.usage.output_tokens,
+            },
+        )
+
     # ------------------------------------------------------------------
     async def generate_grounded_answer(
         self,
@@ -38,15 +49,7 @@ class AnthropicProvider(BaseLLMProvider):
             temperature=0.3,
         )
 
-        return ProviderResponse(
-            text=resp.content[0].text,
-            provider_name="anthropic",
-            model=self._model,
-            usage={
-                "input_tokens": resp.usage.input_tokens,
-                "output_tokens": resp.usage.output_tokens,
-            },
-        )
+        return self._to_response(resp)
 
     # ------------------------------------------------------------------
     async def generate_summary(
@@ -64,15 +67,7 @@ class AnthropicProvider(BaseLLMProvider):
             temperature=0.3,
         )
 
-        return ProviderResponse(
-            text=resp.content[0].text,
-            provider_name="anthropic",
-            model=self._model,
-            usage={
-                "input_tokens": resp.usage.input_tokens,
-                "output_tokens": resp.usage.output_tokens,
-            },
-        )
+        return self._to_response(resp)
 
     # ------------------------------------------------------------------
     async def generate_mod_draft(
@@ -99,15 +94,7 @@ class AnthropicProvider(BaseLLMProvider):
             temperature=0.4,
         )
 
-        return ProviderResponse(
-            text=resp.content[0].text,
-            provider_name="anthropic",
-            model=self._model,
-            usage={
-                "input_tokens": resp.usage.input_tokens,
-                "output_tokens": resp.usage.output_tokens,
-            },
-        )
+        return self._to_response(resp)
 
     # ------------------------------------------------------------------
     async def generate_moderation_analysis(
@@ -135,15 +122,7 @@ class AnthropicProvider(BaseLLMProvider):
             temperature=0.2,
         )
 
-        return ProviderResponse(
-            text=resp.content[0].text,
-            provider_name="anthropic",
-            model=self._model,
-            usage={
-                "input_tokens": resp.usage.input_tokens,
-                "output_tokens": resp.usage.output_tokens,
-            },
-        )
+        return self._to_response(resp)
 
     # ------------------------------------------------------------------
     async def generate_chat_reply(
@@ -161,12 +140,4 @@ class AnthropicProvider(BaseLLMProvider):
             temperature=0.5,
         )
 
-        return ProviderResponse(
-            text=resp.content[0].text,
-            provider_name="anthropic",
-            model=self._model,
-            usage={
-                "input_tokens": resp.usage.input_tokens,
-                "output_tokens": resp.usage.output_tokens,
-            },
-        )
+        return self._to_response(resp)

--- a/backend/providers/openai_provider.py
+++ b/backend/providers/openai_provider.py
@@ -16,6 +16,17 @@ class OpenAIProvider(BaseLLMProvider):
         self._client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
         self._model = settings.OPENAI_MODEL
 
+    def _to_response(self, resp) -> ProviderResponse:
+        return ProviderResponse(
+            text=resp.choices[0].message.content or "",
+            provider_name="openai",
+            model=self._model,
+            usage={
+                "prompt_tokens": resp.usage.prompt_tokens if resp.usage else 0,
+                "completion_tokens": resp.usage.completion_tokens if resp.usage else 0,
+            },
+        )
+
     # ------------------------------------------------------------------
     async def generate_grounded_answer(
         self,
@@ -40,15 +51,7 @@ class OpenAIProvider(BaseLLMProvider):
             temperature=0.3,
         )
 
-        return ProviderResponse(
-            text=resp.choices[0].message.content or "",
-            provider_name="openai",
-            model=self._model,
-            usage={
-                "prompt_tokens": resp.usage.prompt_tokens if resp.usage else 0,
-                "completion_tokens": resp.usage.completion_tokens if resp.usage else 0,
-            },
-        )
+        return self._to_response(resp)
 
     # ------------------------------------------------------------------
     async def generate_summary(
@@ -67,15 +70,7 @@ class OpenAIProvider(BaseLLMProvider):
             temperature=0.3,
         )
 
-        return ProviderResponse(
-            text=resp.choices[0].message.content or "",
-            provider_name="openai",
-            model=self._model,
-            usage={
-                "prompt_tokens": resp.usage.prompt_tokens if resp.usage else 0,
-                "completion_tokens": resp.usage.completion_tokens if resp.usage else 0,
-            },
-        )
+        return self._to_response(resp)
 
     # ------------------------------------------------------------------
     async def generate_mod_draft(
@@ -102,15 +97,7 @@ class OpenAIProvider(BaseLLMProvider):
             temperature=0.4,
         )
 
-        return ProviderResponse(
-            text=resp.choices[0].message.content or "",
-            provider_name="openai",
-            model=self._model,
-            usage={
-                "prompt_tokens": resp.usage.prompt_tokens if resp.usage else 0,
-                "completion_tokens": resp.usage.completion_tokens if resp.usage else 0,
-            },
-        )
+        return self._to_response(resp)
 
     # ------------------------------------------------------------------
     async def generate_moderation_analysis(
@@ -138,15 +125,7 @@ class OpenAIProvider(BaseLLMProvider):
             response_format={"type": "json_object"},
         )
 
-        return ProviderResponse(
-            text=resp.choices[0].message.content or "",
-            provider_name="openai",
-            model=self._model,
-            usage={
-                "prompt_tokens": resp.usage.prompt_tokens if resp.usage else 0,
-                "completion_tokens": resp.usage.completion_tokens if resp.usage else 0,
-            },
-        )
+        return self._to_response(resp)
 
     # ------------------------------------------------------------------
     async def generate_chat_reply(
@@ -167,12 +146,4 @@ class OpenAIProvider(BaseLLMProvider):
             temperature=0.5,
         )
 
-        return ProviderResponse(
-            text=resp.choices[0].message.content or "",
-            provider_name="openai",
-            model=self._model,
-            usage={
-                "prompt_tokens": resp.usage.prompt_tokens if resp.usage else 0,
-                "completion_tokens": resp.usage.completion_tokens if resp.usage else 0,
-            },
-        )
+        return self._to_response(resp)

--- a/backend/services/faq_service.py
+++ b/backend/services/faq_service.py
@@ -2,11 +2,11 @@
 
 import logging
 
-from models.schemas import Citation, TaskResponse
+from models.schemas import TaskResponse
 from models.enums import TaskType
 from prompts.faq_prompt import get_system_prompt
 from services import audit_service, provider_service, retrieval_service
-from services.utils import extract_confidence
+from services.utils import build_citations_and_rule, extract_confidence
 
 logger = logging.getLogger(__name__)
 
@@ -30,25 +30,10 @@ async def ask(question: str) -> TaskResponse:
     # 3. Parse response
     body, confidence_note = extract_confidence(result.text)
 
-    # 4. Build citations from chunks
-    citations = [
-        Citation(
-            source_id=c["source_id"],
-            citation_label=c["citation_label"],
-            snippet=c["content"][:150],
-        )
-        for c in chunks
-    ]
+    # 4. Build citations + rule match + source IDs
+    citations, matched_rule, raw_source_ids = build_citations_and_rule(chunks)
 
-    # 5. Determine matched_rule — first rule-type source, if any
-    matched_rule = next(
-        (c["citation_label"] for c in chunks if c.get("source_type") == "rule"),
-        None,
-    )
-
-    raw_source_ids = [c["source_id"] for c in chunks]
-
-    # 6. Audit
+    # 5. Audit
     await audit_service.log_interaction(
         task_type=TaskType.FAQ.value,
         input_text=question,

--- a/backend/services/mod_draft_service.py
+++ b/backend/services/mod_draft_service.py
@@ -3,10 +3,10 @@
 import logging
 
 from models.enums import TaskType
-from models.schemas import Citation, TaskResponse
+from models.schemas import TaskResponse
 from prompts.mod_draft_prompt import get_system_prompt
 from services import audit_service, provider_service, retrieval_service
-from services.utils import extract_confidence
+from services.utils import build_citations_and_rule, extract_confidence
 
 logger = logging.getLogger(__name__)
 
@@ -29,21 +29,7 @@ async def draft(situation: str) -> TaskResponse:
 
     body, confidence_note = extract_confidence(result.text)
 
-    citations = [
-        Citation(
-            source_id=c["source_id"],
-            citation_label=c["citation_label"],
-            snippet=c["content"][:150],
-        )
-        for c in chunks
-    ]
-
-    matched_rule = next(
-        (c["citation_label"] for c in chunks if c.get("source_type") == "rule"),
-        None,
-    )
-
-    raw_source_ids = [c["source_id"] for c in chunks]
+    citations, matched_rule, raw_source_ids = build_citations_and_rule(chunks)
 
     await audit_service.log_interaction(
         task_type=TaskType.MOD_DRAFT.value,

--- a/backend/services/moderation_service.py
+++ b/backend/services/moderation_service.py
@@ -17,20 +17,9 @@ from models.schemas import ModerationEventResponse
 from prompts.moderation_prompt import get_system_prompt
 from repositories import moderation_repo, settings_repo
 from services import audit_service, provider_service, retrieval_service
+from services.utils import parse_json_response
 
 logger = logging.getLogger(__name__)
-
-
-def _safe_parse_json(text: str) -> dict:
-    """Strip markdown fences and parse JSON.  Returns a dict or raises."""
-    cleaned = (
-        text.strip()
-        .removeprefix("```json")
-        .removeprefix("```")
-        .removesuffix("```")
-        .strip()
-    )
-    return json.loads(cleaned)
 
 
 @dataclass
@@ -69,7 +58,7 @@ async def _run_moderation_llm(text: str) -> ModerationLLMResult:
 
     # Parse JSON response
     try:
-        parsed = _safe_parse_json(result.text)
+        parsed = parse_json_response(result.text)
         violation_type = ViolationType(parsed.get("violation_type", "no_violation"))
         matched_rule = parsed.get("matched_rule")
         explanation = parsed.get("explanation", "")

--- a/backend/services/utils.py
+++ b/backend/services/utils.py
@@ -1,6 +1,9 @@
 """Shared utilities for service modules."""
 
+import json
 import re
+
+from models.schemas import Citation
 
 
 def extract_confidence(text: str) -> tuple[str, str | None]:
@@ -15,3 +18,35 @@ def extract_confidence(text: str) -> tuple[str, str | None]:
         confidence_note = match.group(0).strip()
         return body, confidence_note
     return text.strip(), None
+
+
+def parse_json_response(text: str) -> dict:
+    """Strip markdown fences from an LLM reply and parse the JSON body."""
+    cleaned = (
+        text.strip()
+        .removeprefix("```json")
+        .removeprefix("```")
+        .removesuffix("```")
+        .strip()
+    )
+    return json.loads(cleaned)
+
+
+def build_citations_and_rule(
+    chunks: list[dict],
+) -> tuple[list[Citation], str | None, list[str]]:
+    """Build Citation objects, pick the first rule-type label, and collect source IDs."""
+    citations = [
+        Citation(
+            source_id=c["source_id"],
+            citation_label=c["citation_label"],
+            snippet=c["content"][:150],
+        )
+        for c in chunks
+    ]
+    matched_rule = next(
+        (c["citation_label"] for c in chunks if c.get("source_type") == "rule"),
+        None,
+    )
+    raw_source_ids = [c["source_id"] for c in chunks]
+    return citations, matched_rule, raw_source_ids

--- a/bot/cogs/monitor.py
+++ b/bot/cogs/monitor.py
@@ -13,11 +13,6 @@ from embeds import build_moderation_alert
 
 log = logging.getLogger(__name__)
 
-# Actions that warrant auto-deletion in demo mode
-AUTO_DELETE_ACTIONS = frozenset(
-    {"remove_message", "timeout_or_mute_recommendation", "escalate_to_human"}
-)
-
 # Per-user cooldown in seconds
 COOLDOWN_SECONDS = 5.0
 
@@ -78,11 +73,10 @@ class MonitorCog(commands.Cog):
         if data.get("suggested_action") == "no_action":
             return
 
-        # 3. Check demo mode
-        demo_mode = await client.get_demo_mode()
-
-        if demo_mode and data.get("suggested_action") in AUTO_DELETE_ACTIONS:
-            # Demo mode: auto-delete and alert
+        # 3. Backend already decided demo-mode action — trust the status field.
+        #    (moderation_service.analyze sets status=auto_actioned when demo_mode
+        #    is on AND the action is one of the auto-delete triggers.)
+        if data.get("status") == "auto_actioned":
             try:
                 await message.delete()
             except discord.Forbidden:

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -52,6 +52,20 @@
   overflow-y: auto;
 }
 
+.app__retry-btn {
+  padding: 8px 24px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #ffffff;
+  background-color: var(--color-primary);
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+}
+
+.app__retry-btn:hover:not(:disabled) {
+  background-color: var(--color-primary-hover);
+}
+
 .app__footer {
   grid-area: footer;
   display: flex;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,7 +37,8 @@ export default function App() {
   const [demoMode, setDemoModeState] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState("connecting"); // "connecting" | "connected" | "failed"
 
-  useEffect(() => {
+  const connect = () => {
+    setConnectionStatus("connecting");
     healthCheck()
       .then(() => {
         setConnectionStatus("connected");
@@ -47,6 +48,11 @@ export default function App() {
       .catch(() => {
         setConnectionStatus("failed");
       });
+  };
+
+  useEffect(() => {
+    connect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleToggleDemo = async () => {
@@ -73,8 +79,20 @@ export default function App() {
   if (connectionStatus === "failed") {
     return (
       <div className="app">
-        <main className="app__content" style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <main
+          className="app__content"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "16px",
+          }}
+        >
           <p>Backend unavailable &mdash; check that the server is running.</p>
+          <button className="app__retry-btn" onClick={connect}>
+            Retry
+          </button>
         </main>
       </div>
     );

--- a/frontend/src/components/ModerationHistory.css
+++ b/frontend/src/components/ModerationHistory.css
@@ -93,7 +93,6 @@
 .moderation-history__list {
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  overflow: hidden;
 }
 
 .moderation-history__table-header {
@@ -108,6 +107,11 @@
   color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
 }
 
 .moderation-history__row {

--- a/frontend/src/components/ModerationHistory.jsx
+++ b/frontend/src/components/ModerationHistory.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { getHistory } from "../api.js";
 import SeverityBadge from "./shared/SeverityBadge.jsx";
 import RuleMatchChip from "./shared/RuleMatchChip.jsx";
+import { formatEnumValue } from "../utils/formatEnum.js";
 import "./ModerationHistory.css";
 
 const STATUS_FILTERS = [
@@ -170,7 +171,7 @@ export default function ModerationHistory() {
                       event.status
                     )}`}
                   >
-                    {event.status ? event.status.replace(/_/g, " ") : "--"}
+                    {event.status ? formatEnumValue(event.status) : "--"}
                   </span>
                 </span>
                 <span className="moderation-history__col moderation-history__col--rule">
@@ -213,7 +214,7 @@ export default function ModerationHistory() {
                     </span>
                     <span>
                       {event.suggested_action
-                        ? event.suggested_action.replace(/_/g, " ")
+                        ? formatEnumValue(event.suggested_action)
                         : "--"}
                     </span>
                   </div>

--- a/frontend/src/components/ReviewQueue.css
+++ b/frontend/src/components/ReviewQueue.css
@@ -79,6 +79,39 @@
   border-radius: 8px;
   padding: 16px;
   margin-bottom: 12px;
+  transition: opacity 0.2s ease, filter 0.2s ease;
+}
+
+.review-queue__card--busy {
+  opacity: 0.6;
+  filter: grayscale(30%);
+  pointer-events: none;
+}
+
+.review-queue__card--busy .review-queue__card-actions {
+  pointer-events: auto;
+}
+
+.review-queue__btn-busy {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.review-queue__spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: review-queue-spin 0.8s linear infinite;
+}
+
+@keyframes review-queue-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .review-queue__card-top {

--- a/frontend/src/components/ReviewQueue.jsx
+++ b/frontend/src/components/ReviewQueue.jsx
@@ -129,48 +129,77 @@ export default function ReviewQueue() {
         )}
 
         {!loading &&
-          pendingEvents.map((event) => (
-            <div key={event.event_id} className="review-queue__card">
-              <div className="review-queue__card-top">
-                <div className="review-queue__card-badges">
-                  <SeverityBadge level={event.severity} />
-                  <RuleMatchChip rule={event.matched_rule} />
+          pendingEvents.map((event) => {
+            const isBusy = actionLoading === event.event_id;
+            return (
+              <div
+                key={event.event_id}
+                className={`review-queue__card${
+                  isBusy ? " review-queue__card--busy" : ""
+                }`}
+                aria-busy={isBusy}
+              >
+                <div className="review-queue__card-top">
+                  <div className="review-queue__card-badges">
+                    <SeverityBadge level={event.severity} />
+                    <RuleMatchChip rule={event.matched_rule} />
+                  </div>
+                  {event.suggested_action && (
+                    <span className="review-queue__suggested-action">
+                      Suggested: {formatEnumValue(event.suggested_action)}
+                    </span>
+                  )}
                 </div>
-                {event.suggested_action && (
-                  <span className="review-queue__suggested-action">
-                    Suggested: {formatEnumValue(event.suggested_action)}
-                  </span>
+
+                <div className="review-queue__card-message">
+                  {event.message_content}
+                </div>
+
+                {event.explanation && (
+                  <p className="review-queue__card-explanation">
+                    {event.explanation}
+                  </p>
                 )}
-              </div>
 
-              <div className="review-queue__card-message">
-                {event.message_content}
+                <div className="review-queue__card-actions">
+                  <button
+                    className="review-queue__approve-btn"
+                    onClick={() => handleApprove(event.event_id)}
+                    disabled={isBusy}
+                  >
+                    {isBusy ? (
+                      <span className="review-queue__btn-busy">
+                        <span
+                          className="review-queue__spinner"
+                          aria-hidden="true"
+                        />
+                        Processing…
+                      </span>
+                    ) : (
+                      "Approve"
+                    )}
+                  </button>
+                  <button
+                    className="review-queue__reject-btn"
+                    onClick={() => handleReject(event.event_id)}
+                    disabled={isBusy}
+                  >
+                    {isBusy ? (
+                      <span className="review-queue__btn-busy">
+                        <span
+                          className="review-queue__spinner"
+                          aria-hidden="true"
+                        />
+                        Processing…
+                      </span>
+                    ) : (
+                      "Reject"
+                    )}
+                  </button>
+                </div>
               </div>
-
-              {event.explanation && (
-                <p className="review-queue__card-explanation">
-                  {event.explanation}
-                </p>
-              )}
-
-              <div className="review-queue__card-actions">
-                <button
-                  className="review-queue__approve-btn"
-                  onClick={() => handleApprove(event.event_id)}
-                  disabled={actionLoading === event.event_id}
-                >
-                  {actionLoading === event.event_id ? "..." : "Approve"}
-                </button>
-                <button
-                  className="review-queue__reject-btn"
-                  onClick={() => handleReject(event.event_id)}
-                  disabled={actionLoading === event.event_id}
-                >
-                  {actionLoading === event.event_id ? "..." : "Reject"}
-                </button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
       </div>
     </div>
   );

--- a/frontend/src/components/ReviewQueue.jsx
+++ b/frontend/src/components/ReviewQueue.jsx
@@ -10,6 +10,7 @@ import PromptInput from "./shared/PromptInput.jsx";
 import ResponsePanel from "./shared/ResponsePanel.jsx";
 import SeverityBadge from "./shared/SeverityBadge.jsx";
 import RuleMatchChip from "./shared/RuleMatchChip.jsx";
+import { formatEnumValue } from "../utils/formatEnum.js";
 import "./ReviewQueue.css";
 
 export default function ReviewQueue() {
@@ -137,7 +138,7 @@ export default function ReviewQueue() {
                 </div>
                 {event.suggested_action && (
                   <span className="review-queue__suggested-action">
-                    Suggested: {event.suggested_action.replace(/_/g, " ")}
+                    Suggested: {formatEnumValue(event.suggested_action)}
                   </span>
                 )}
               </div>

--- a/frontend/src/components/shared/ResponsePanel.jsx
+++ b/frontend/src/components/shared/ResponsePanel.jsx
@@ -1,6 +1,7 @@
 import SeverityBadge from "./SeverityBadge.jsx";
 import RuleMatchChip from "./RuleMatchChip.jsx";
 import CitationBadge from "./CitationBadge.jsx";
+import { formatEnumValue } from "../../utils/formatEnum.js";
 import "./ResponsePanel.css";
 
 export default function ResponsePanel({ response }) {
@@ -33,7 +34,7 @@ export default function ResponsePanel({ response }) {
           <div className="response-panel__meta-row">
             <span className="response-panel__meta-label">Suggested Action:</span>
             <span className="response-panel__action">
-              {suggested_action.replace(/_/g, " ")}
+              {formatEnumValue(suggested_action)}
             </span>
           </div>
         )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,12 +63,21 @@ button {
   font-size: inherit;
   cursor: pointer;
   border: none;
+}
+
+button:focus {
   outline: none;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.5;
+  opacity: 0.55;
+  filter: grayscale(30%);
 }
 
 input,

--- a/frontend/src/utils/formatEnum.js
+++ b/frontend/src/utils/formatEnum.js
@@ -1,0 +1,5 @@
+/** Turn a snake_case enum value into a space-separated string for display. */
+export function formatEnumValue(value) {
+  if (!value) return "";
+  return String(value).replace(/_/g, " ");
+}


### PR DESCRIPTION
## Summary

Two-track pass on the esports-mod-copilot portal:

**Simplification (4 commits)**
- Shared helpers: `parse_json_response`, `build_citations_and_rule` (backend/services/utils.py) collapse duplication in moderation_service, faq_service, mod_draft_service
- `_to_response` helper per provider (OpenAI + Anthropic) — each `generate_*` method now normalises through one code path
- Bot monitor trusts backend `status=auto_actioned` instead of re-computing the demo-mode decision with a duplicated frozenset
- Frontend `formatEnumValue` utility replaces three ad-hoc `.replace(/_/g, " ")` sites

**UX P1 polish (1 commit)**
- Sticky table header on Moderation History
- `:focus-visible` keyboard ring restored on buttons (was suppressed by a blanket `outline: none`); hidden mouse-focus preserved
- `button:disabled` gets a grayscale tint in addition to opacity for clearer signal
- Retry button on backend-unavailable screen — reruns health check without a page reload
- Review Queue approve/reject: card dims while the action is in flight and the button swaps `"..."` for a spinner + `"Processing…"`

## Test plan
- [x] 298 backend tests pass
- [x] 52 bot tests pass
- [x] 33 data tests pass
- [x] Frontend `npm run build` clean
- [x] Bot package parses with no syntax errors
- [ ] Manual smoke test of Review Queue approve/reject in the portal
- [ ] Manual verification of sticky header on Moderation History with >20 events

## Notes
Progressive Discipline v2 (warn→kick escalation, severity-weighted toxicity score, Test Mode, Undo UI) is designed and documented in PAM but deferred to a follow-up PR — it's a data-model + policy change large enough to warrant its own review window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)