### PR TITLE
Progressive Discipline v2 (warn → kick → timed-ban)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -36,10 +36,44 @@ CREATE TABLE IF NOT EXISTS moderation_events (
     source TEXT NOT NULL DEFAULT 'dashboard' CHECK(source IN ('discord','dashboard')),
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     resolved_at TEXT,
-    resolved_by TEXT
+    resolved_by TEXT,
+    discord_user_id TEXT,
+    discord_guild_id TEXT,
+    discipline_action TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_mod_events_status ON moderation_events(status);
 CREATE INDEX IF NOT EXISTS idx_mod_events_created ON moderation_events(created_at DESC);
+-- NOTE: idx_mod_events_user is created AFTER the ALTER TABLE ADD COLUMN
+-- migration below, since the indexed columns don't exist yet on legacy DBs.
+
+CREATE TABLE IF NOT EXISTS user_violations (
+    violation_id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL,
+    guild_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    category TEXT NOT NULL,
+    severity TEXT NOT NULL CHECK(severity IN ('low','medium','high','critical')),
+    points INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    revoked_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_user_violations_user ON user_violations(guild_id, user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS mod_actions (
+    action_id TEXT PRIMARY KEY,
+    event_id TEXT,
+    guild_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    action_type TEXT NOT NULL CHECK(action_type IN ('warn','kick','timed_ban','undo','delete_message')),
+    reason TEXT,
+    actor TEXT NOT NULL,
+    test_mode INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    undone_at TEXT,
+    details TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_mod_actions_user ON mod_actions(guild_id, user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_mod_actions_event ON mod_actions(event_id);
 
 CREATE TABLE IF NOT EXISTS interaction_history (
     interaction_id TEXT PRIMARY KEY,
@@ -114,9 +148,46 @@ async def init_db() -> None:
             )
 
         await db.executescript(_DDL)
+
+        # ------------------------------------------------------------------
+        # Migration: add discord_user_id, discord_guild_id, discipline_action
+        # to moderation_events on existing databases. SQLite accepts
+        # ADD COLUMN for nullable TEXT without issue.
+        # ------------------------------------------------------------------
+        async with db.execute("PRAGMA table_info(moderation_events)") as cur:
+            cols = {row[1] for row in await cur.fetchall()}
+        for col_def in (
+            ("discord_user_id", "TEXT"),
+            ("discord_guild_id", "TEXT"),
+            ("discipline_action", "TEXT"),
+        ):
+            name, sql_type = col_def
+            if name not in cols:
+                await db.execute(
+                    f"ALTER TABLE moderation_events ADD COLUMN {name} {sql_type}"
+                )
+                logger.info("Added moderation_events.%s column", name)
+
+        # Now that the columns definitely exist, create the composite index.
         await db.execute(
-            "INSERT OR IGNORE INTO app_settings VALUES ('demo_mode', 'true')"
+            "CREATE INDEX IF NOT EXISTS idx_mod_events_user "
+            "ON moderation_events(discord_guild_id, discord_user_id, created_at DESC)"
         )
+
+        # Seed settings defaults — only inserted if the key is missing.
+        _DEFAULT_SETTINGS = [
+            ("demo_mode", "true"),
+            ("test_mode", "false"),
+            ("discipline_points_threshold", "5"),
+            ("discipline_window_days", "30"),
+            ("discipline_repeat_category_kicks", "true"),
+            ("discipline_ban_minutes", "60"),
+        ]
+        for key, value in _DEFAULT_SETTINGS:
+            await db.execute(
+                "INSERT OR IGNORE INTO app_settings (key, value) VALUES (?, ?)",
+                (key, value),
+            )
         await db.commit()
     logger.info("Database initialized successfully")
 

--- a/backend/models/enums.py
+++ b/backend/models/enums.py
@@ -54,3 +54,22 @@ class ViolationType(str, Enum):
 class EventSource(str, Enum):
     DISCORD = "discord"
     DASHBOARD = "dashboard"
+
+
+class DisciplineAction(str, Enum):
+    """Outcome of the progressive-discipline engine for a single event."""
+
+    NONE = "none"
+    WARN = "warn"
+    KICK = "kick"
+    TIMED_BAN = "timed_ban"
+
+
+class ModActionType(str, Enum):
+    """Types of recorded moderator or bot actions (audit trail)."""
+
+    WARN = "warn"
+    KICK = "kick"
+    TIMED_BAN = "timed_ban"
+    UNDO = "undo"
+    DELETE_MESSAGE = "delete_message"

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field, field_validator
 
 from models.enums import (
+    DisciplineAction,
     EventSource,
     ModerationStatus,
     Severity,
@@ -67,6 +68,17 @@ class TaskResponse(BaseModel):
 # Moderation events
 # ---------------------------------------------------------------------------
 
+class DisciplineDecisionPayload(BaseModel):
+    """Serialised discipline-engine output for API responses."""
+
+    action: DisciplineAction
+    reason: str
+    points_total: int
+    window_days: int
+    test_mode: bool
+    ban_minutes: int | None = None
+
+
 class ModerationEventResponse(BaseModel):
     event_id: str
     message_content: str
@@ -80,6 +92,12 @@ class ModerationEventResponse(BaseModel):
     created_at: str
     resolved_at: str | None = None
     resolved_by: str | None = None
+    discord_user_id: str | None = None
+    discord_guild_id: str | None = None
+    discipline_action: DisciplineAction | None = None
+    # Populated only on the immediate /analyze response — not stored on
+    # the event row. Lets the bot act on the decision without a second call.
+    discipline_decision: DisciplineDecisionPayload | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +119,22 @@ class ModDraftRequest(BaseModel):
 class AnalyzeRequest(BaseModel):
     message_content: str
     source: EventSource = EventSource.DASHBOARD
+    # Bot populates these for Discord-sourced analyses so the discipline
+    # engine knows whose ledger to update. Dashboard analyses (Review Queue
+    # test box) leave them unset and skip the discipline branch.
+    discord_user_id: str | None = None
+    discord_guild_id: str | None = None
+
+    @field_validator("discord_user_id", "discord_guild_id")
+    @classmethod
+    def _validate_optional_snowflake(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not re.fullmatch(r"\d{1,20}", v):
+            raise ValueError(
+                "must be a Discord snowflake (1–20 decimal digits)"
+            )
+        return v
 
 
 class DemoModeRequest(BaseModel):

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -224,3 +224,48 @@ class ChatEnabledRequest(BaseModel):
 
 class ChatEnabledResponse(BaseModel):
     chat_enabled: bool
+
+
+# ---------------------------------------------------------------------------
+# Generic settings CRUD
+# ---------------------------------------------------------------------------
+
+
+# Only these keys are writeable via the generic settings endpoint. The
+# allow-list is intentional: it keeps ad-hoc new keys from being injected
+# via the portal and, more importantly, prevents secrets (API keys,
+# Discord tokens, HMAC secrets) from ever being surfaced here. Secrets
+# remain env-only and never pass through this endpoint.
+WRITEABLE_SETTINGS_KEYS = frozenset(
+    {
+        "demo_mode",
+        "test_mode",
+        "chat_enabled",
+        "discipline_points_threshold",
+        "discipline_window_days",
+        "discipline_repeat_category_kicks",
+        "discipline_ban_minutes",
+    }
+)
+
+
+class SettingsPayload(BaseModel):
+    """Current value of every exposed setting + typed conveniences."""
+
+    settings: dict[str, str]
+
+
+class SettingsBatchUpdate(BaseModel):
+    """Dict of key → string value. Server rejects keys outside the allow-list."""
+
+    updates: dict[str, str]
+
+    @field_validator("updates")
+    @classmethod
+    def _reject_unknown_keys(cls, v: dict[str, str]) -> dict[str, str]:
+        extras = set(v) - WRITEABLE_SETTINGS_KEYS
+        if extras:
+            raise ValueError(
+                f"unknown or non-writeable settings keys: {sorted(extras)}"
+            )
+        return v

--- a/backend/repositories/__init__.py
+++ b/backend/repositories/__init__.py
@@ -1,5 +1,17 @@
 """Data-access repositories."""
 
-from repositories import history_repo, knowledge_repo, moderation_repo, settings_repo
+from repositories import (
+    discipline_repo,
+    history_repo,
+    knowledge_repo,
+    moderation_repo,
+    settings_repo,
+)
 
-__all__ = ["history_repo", "knowledge_repo", "moderation_repo", "settings_repo"]
+__all__ = [
+    "discipline_repo",
+    "history_repo",
+    "knowledge_repo",
+    "moderation_repo",
+    "settings_repo",
+]

--- a/backend/repositories/discipline_repo.py
+++ b/backend/repositories/discipline_repo.py
@@ -182,7 +182,12 @@ async def mark_actions_undone_for_event(event_id: str) -> int:
 
 
 async def has_kick_for_user(guild_id: str, user_id: str) -> bool:
-    """Return True if there is a non-undone kick on record for this user."""
+    """Return True if there is a real (non-test-mode, non-undone) kick on record.
+
+    Test-mode kicks are excluded so dry-run runs don't poison the reoffense
+    lookup: once test mode is turned off, real violations must not be
+    escalated on the basis of a simulated kick that never actually happened.
+    """
     async with aiosqlite.connect(settings.SQLITE_PATH) as db:
         cursor = await db.execute(
             """
@@ -191,6 +196,7 @@ async def has_kick_for_user(guild_id: str, user_id: str) -> bool:
                AND user_id = ?
                AND action_type = 'kick'
                AND undone_at IS NULL
+               AND test_mode = 0
              LIMIT 1
             """,
             (guild_id, user_id),

--- a/backend/repositories/discipline_repo.py
+++ b/backend/repositories/discipline_repo.py
@@ -1,0 +1,211 @@
+"""Repository for user_violations + mod_actions tables.
+
+Progressive-discipline bookkeeping. Each auto-actioned event contributes
+one user_violations row (the severity-weighted "point ledger") and one
+mod_actions row (the audit trail). Undo by the dashboard revokes both.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+import aiosqlite
+
+from config import settings
+from models.enums import ModActionType, Severity
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# severity → points (design decision, see PAM project doc)
+# ---------------------------------------------------------------------------
+
+SEVERITY_POINTS: dict[Severity, int] = {
+    Severity.LOW: 1,
+    Severity.MEDIUM: 2,
+    Severity.HIGH: 3,
+    Severity.CRITICAL: 5,
+}
+
+
+def points_for(severity: Severity) -> int:
+    return SEVERITY_POINTS.get(severity, 1)
+
+
+# ---------------------------------------------------------------------------
+# user_violations
+# ---------------------------------------------------------------------------
+
+
+async def add_violation(
+    *,
+    event_id: str,
+    guild_id: str,
+    user_id: str,
+    category: str,
+    severity: Severity,
+) -> str:
+    """Insert a violation row and return its violation_id."""
+    violation_id = uuid.uuid4().hex
+    points = points_for(severity)
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute(
+            """
+            INSERT INTO user_violations
+                (violation_id, event_id, guild_id, user_id, category, severity, points)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (violation_id, event_id, guild_id, user_id, category, severity.value, points),
+        )
+        await db.commit()
+    return violation_id
+
+
+async def sum_points_in_window(
+    guild_id: str, user_id: str, window_days: int
+) -> int:
+    """Sum un-revoked points in the rolling window for (guild_id, user_id)."""
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        cursor = await db.execute(
+            """
+            SELECT COALESCE(SUM(points), 0) FROM user_violations
+             WHERE guild_id = ?
+               AND user_id = ?
+               AND revoked_at IS NULL
+               AND created_at >= datetime('now', ?)
+            """,
+            (guild_id, user_id, f"-{window_days} days"),
+        )
+        row = await cursor.fetchone()
+        return int(row[0]) if row else 0
+
+
+async def count_same_category_in_window(
+    guild_id: str, user_id: str, category: str, window_days: int
+) -> int:
+    """Count un-revoked same-category violations in the rolling window."""
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        cursor = await db.execute(
+            """
+            SELECT COUNT(*) FROM user_violations
+             WHERE guild_id = ?
+               AND user_id = ?
+               AND category = ?
+               AND revoked_at IS NULL
+               AND created_at >= datetime('now', ?)
+            """,
+            (guild_id, user_id, category, f"-{window_days} days"),
+        )
+        row = await cursor.fetchone()
+        return int(row[0]) if row else 0
+
+
+async def revoke_all_for_user(guild_id: str, user_id: str) -> int:
+    """Mark every active violation for a user as revoked. Returns row count."""
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        cursor = await db.execute(
+            """
+            UPDATE user_violations
+               SET revoked_at = datetime('now')
+             WHERE guild_id = ?
+               AND user_id = ?
+               AND revoked_at IS NULL
+            """,
+            (guild_id, user_id),
+        )
+        await db.commit()
+        return cursor.rowcount or 0
+
+
+# ---------------------------------------------------------------------------
+# mod_actions
+# ---------------------------------------------------------------------------
+
+
+async def record_action(
+    *,
+    event_id: str | None,
+    guild_id: str,
+    user_id: str,
+    action_type: ModActionType,
+    actor: str,
+    reason: str | None = None,
+    test_mode: bool = False,
+    details: str | None = None,
+) -> str:
+    """Insert an audit row and return its action_id."""
+    action_id = uuid.uuid4().hex
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute(
+            """
+            INSERT INTO mod_actions
+                (action_id, event_id, guild_id, user_id, action_type,
+                 reason, actor, test_mode, details)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                action_id,
+                event_id,
+                guild_id,
+                user_id,
+                action_type.value,
+                reason,
+                actor,
+                1 if test_mode else 0,
+                details,
+            ),
+        )
+        await db.commit()
+    return action_id
+
+
+async def mark_actions_undone_for_event(event_id: str) -> int:
+    """Mark every non-undo action row for this event as undone. Returns count."""
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        cursor = await db.execute(
+            """
+            UPDATE mod_actions
+               SET undone_at = datetime('now')
+             WHERE event_id = ?
+               AND action_type != 'undo'
+               AND undone_at IS NULL
+            """,
+            (event_id,),
+        )
+        await db.commit()
+        return cursor.rowcount or 0
+
+
+async def has_kick_for_user(guild_id: str, user_id: str) -> bool:
+    """Return True if there is a non-undone kick on record for this user."""
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        cursor = await db.execute(
+            """
+            SELECT 1 FROM mod_actions
+             WHERE guild_id = ?
+               AND user_id = ?
+               AND action_type = 'kick'
+               AND undone_at IS NULL
+             LIMIT 1
+            """,
+            (guild_id, user_id),
+        )
+        row = await cursor.fetchone()
+        return row is not None
+
+
+async def list_for_event(event_id: str) -> list[dict[str, Any]]:
+    """Return audit rows for a moderation event (for the dashboard drawer)."""
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT * FROM mod_actions WHERE event_id = ? ORDER BY created_at ASC",
+            (event_id,),
+        )
+        rows = await cursor.fetchall()
+        return [dict(row) for row in rows]

--- a/backend/repositories/moderation_repo.py
+++ b/backend/repositories/moderation_repo.py
@@ -20,6 +20,14 @@ logger = logging.getLogger(__name__)
 
 def _row_to_event(row: aiosqlite.Row) -> ModerationEventResponse:
     """Map a DB row to a ModerationEventResponse."""
+    # aiosqlite.Row supports keys() lookup; use .get-style with try/except to
+    # stay robust against old rows from before the discipline columns existed.
+    def _maybe(col: str) -> str | None:
+        try:
+            return row[col]
+        except (IndexError, KeyError):
+            return None
+
     return ModerationEventResponse(
         event_id=row["event_id"],
         message_content=row["message_content"],
@@ -33,6 +41,9 @@ def _row_to_event(row: aiosqlite.Row) -> ModerationEventResponse:
         created_at=row["created_at"],
         resolved_at=row["resolved_at"],
         resolved_by=row["resolved_by"],
+        discord_user_id=_maybe("discord_user_id"),
+        discord_guild_id=_maybe("discord_guild_id"),
+        discipline_action=_maybe("discipline_action"),
     )
 
 
@@ -47,6 +58,8 @@ async def create(
     suggested_action: SuggestedAction,
     status: ModerationStatus,
     source: EventSource,
+    discord_user_id: str | None = None,
+    discord_guild_id: str | None = None,
 ) -> ModerationEventResponse:
     """Insert a new moderation event and return it."""
     async with aiosqlite.connect(settings.SQLITE_PATH) as db:
@@ -57,8 +70,9 @@ async def create(
             """
             INSERT INTO moderation_events
                 (event_id, message_content, violation_type, matched_rule,
-                 explanation, severity, suggested_action, status, source)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 explanation, severity, suggested_action, status, source,
+                 discord_user_id, discord_guild_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 event_id,
@@ -70,6 +84,8 @@ async def create(
                 suggested_action.value,
                 status.value,
                 source.value,
+                discord_user_id,
+                discord_guild_id,
             ),
         )
         await db.commit()
@@ -79,6 +95,17 @@ async def create(
         )
         row = await cursor.fetchone()
         return _row_to_event(row)
+
+
+async def set_discipline_action(event_id: str, action: str) -> None:
+    """Persist the discipline-engine decision on the event row."""
+    async with aiosqlite.connect(settings.SQLITE_PATH) as db:
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute(
+            "UPDATE moderation_events SET discipline_action = ? WHERE event_id = ?",
+            (action, event_id),
+        )
+        await db.commit()
 
 
 async def get_by_id(event_id: str) -> ModerationEventResponse | None:

--- a/backend/repositories/settings_repo.py
+++ b/backend/repositories/settings_repo.py
@@ -43,3 +43,36 @@ async def get_demo_mode() -> bool:
 async def set_demo_mode(enabled: bool) -> None:
     """Convenience: persist demo_mode."""
     await set("demo_mode", "true" if enabled else "false")
+
+
+# ---------------------------------------------------------------------------
+# Typed helpers
+# ---------------------------------------------------------------------------
+
+
+async def get_bool(key: str, default: bool) -> bool:
+    val = await get(key)
+    if val is None:
+        return default
+    return val == "true"
+
+
+async def get_int(key: str, default: int) -> int:
+    val = await get(key)
+    if val is None:
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        logger.warning("app_settings.%s is not an int: %r; using default %d", key, val, default)
+        return default
+
+
+async def get_all() -> dict[str, str]:
+    """Return every row from app_settings as a dict."""
+    async with aiosqlite.connect(app_settings.SQLITE_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        await db.execute("PRAGMA journal_mode=WAL")
+        cursor = await db.execute("SELECT key, value FROM app_settings")
+        rows = await cursor.fetchall()
+        return {row["key"]: row["value"] for row in rows}

--- a/backend/routes/moderation.py
+++ b/backend/routes/moderation.py
@@ -1,4 +1,4 @@
-"""Moderation endpoints — analyze, approve, reject, and draft."""
+"""Moderation endpoints — analyze, approve, reject, draft, undo."""
 
 from fastapi import APIRouter, HTTPException
 
@@ -8,7 +8,7 @@ from models.schemas import (
     ModerationEventResponse,
     TaskResponse,
 )
-from services import mod_draft_service, moderation_service
+from services import discipline_service, mod_draft_service, moderation_service
 
 router = APIRouter()
 
@@ -20,7 +20,12 @@ async def draft_mod_response(body: ModDraftRequest) -> TaskResponse:
 
 @router.post("/analyze", response_model=ModerationEventResponse)
 async def analyze_message(body: AnalyzeRequest) -> ModerationEventResponse:
-    return await moderation_service.analyze(body.message_content, body.source)
+    return await moderation_service.analyze(
+        body.message_content,
+        body.source,
+        discord_user_id=body.discord_user_id,
+        discord_guild_id=body.discord_guild_id,
+    )
 
 
 @router.post("/approve/{event_id}", response_model=ModerationEventResponse)
@@ -37,3 +42,22 @@ async def reject_event(event_id: str) -> ModerationEventResponse:
     if event is None:
         raise HTTPException(status_code=404, detail="Event not found")
     return event
+
+
+@router.post("/undo/{event_id}")
+async def undo_event(event_id: str) -> dict:
+    """Revoke the discipline action attached to an event and reset the ledger.
+
+    Returns 404 when the event does not exist, 409 when it has no Discord
+    context to undo against (dashboard-sourced analyses, for instance).
+    """
+    result = await discipline_service.undo_for_event(event_id)
+    if not result.get("undone"):
+        reason = result.get("reason", "unknown")
+        if reason == "event_not_found":
+            raise HTTPException(status_code=404, detail="Event not found")
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot undo event: {reason}",
+        )
+    return result

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -1,12 +1,15 @@
-"""Settings endpoints — demo-mode toggle and chat-enabled flag."""
+"""Settings endpoints — demo-mode toggle, chat flag, and generic settings CRUD."""
 
 from fastapi import APIRouter
 
 from models.schemas import (
+    WRITEABLE_SETTINGS_KEYS,
     ChatEnabledRequest,
     ChatEnabledResponse,
     DemoModeRequest,
     DemoModeResponse,
+    SettingsBatchUpdate,
+    SettingsPayload,
 )
 from repositories import settings_repo
 
@@ -38,3 +41,32 @@ async def set_chat_enabled_setting(body: ChatEnabledRequest) -> ChatEnabledRespo
     """Persist the chat-enabled flag via the generic settings_repo."""
     await settings_repo.set("chat_enabled", "true" if body.enabled else "false")
     return ChatEnabledResponse(chat_enabled=body.enabled)
+
+
+# ---------------------------------------------------------------------------
+# Generic settings CRUD (allow-listed keys only)
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=SettingsPayload)
+async def get_all_settings() -> SettingsPayload:
+    """Return every app_setting value, filtered to the writeable allow-list.
+
+    Secrets (API keys, Discord tokens, HMAC secrets) are never stored in
+    app_settings and therefore never appear here — they remain env-only.
+    """
+    all_rows = await settings_repo.get_all()
+    filtered = {k: v for k, v in all_rows.items() if k in WRITEABLE_SETTINGS_KEYS}
+    # Ensure every allow-listed key appears even if the row is missing, so
+    # the portal can render a full form without defensive null checks.
+    for key in WRITEABLE_SETTINGS_KEYS:
+        filtered.setdefault(key, "")
+    return SettingsPayload(settings=filtered)
+
+
+@router.post("", response_model=SettingsPayload)
+async def update_settings(body: SettingsBatchUpdate) -> SettingsPayload:
+    """Upsert one or more app_settings rows. 422 on unknown keys."""
+    for key, value in body.updates.items():
+        await settings_repo.set(key, value)
+    return await get_all_settings()

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -3,6 +3,7 @@
 from services import (
     audit_service,
     chat_service,
+    discipline_service,
     faq_service,
     mod_draft_service,
     moderation_service,
@@ -14,6 +15,7 @@ from services import (
 __all__ = [
     "audit_service",
     "chat_service",
+    "discipline_service",
     "faq_service",
     "mod_draft_service",
     "moderation_service",

--- a/backend/services/discipline_service.py
+++ b/backend/services/discipline_service.py
@@ -1,0 +1,260 @@
+"""Progressive-discipline engine.
+
+Given a moderation event that would have triggered a demo-mode auto-action,
+this module decides which *escalation* to apply (warn / kick / timed_ban)
+and records the ledger rows. The bot is responsible for executing the
+decision on Discord (the decision is policy, the execution is plumbing).
+
+Decision tree (order matters — first match wins):
+
+  1. If a (guild_id, user_id) already has a non-undone kick on record and
+     offends again → TIMED_BAN.
+  2. If the severity-weighted point sum in the rolling window reaches the
+     configured threshold → KICK.
+  3. If the "repeat category kicks" policy is ON and this is at least the
+     second un-revoked same-category violation in the window → KICK.
+  4. Otherwise → WARN.
+
+Only auto-actioned events feed into the engine — approved/rejected events
+in the review queue are not policy decisions, they are human choices.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+from models.enums import DisciplineAction, ModActionType, Severity
+from repositories import discipline_repo, settings_repo
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DisciplineDecision:
+    """Engine output for a single event."""
+
+    action: DisciplineAction
+    reason: str
+    points_total: int
+    window_days: int
+    test_mode: bool
+    ban_minutes: int | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "action": self.action.value,
+            "reason": self.reason,
+            "points_total": self.points_total,
+            "window_days": self.window_days,
+            "test_mode": self.test_mode,
+            "ban_minutes": self.ban_minutes,
+        }
+
+
+async def _load_policy() -> dict:
+    """Fetch the current discipline policy from app_settings."""
+    return {
+        "test_mode": await settings_repo.get_bool("test_mode", False),
+        "threshold": await settings_repo.get_int("discipline_points_threshold", 5),
+        "window_days": await settings_repo.get_int("discipline_window_days", 30),
+        "repeat_category_kicks": await settings_repo.get_bool(
+            "discipline_repeat_category_kicks", True
+        ),
+        "ban_minutes": await settings_repo.get_int("discipline_ban_minutes", 60),
+    }
+
+
+async def decide_and_record(
+    *,
+    event_id: str,
+    guild_id: str,
+    user_id: str,
+    category: str,
+    severity: Severity,
+) -> DisciplineDecision:
+    """Record the violation, decide escalation, write the mod_actions row.
+
+    This is the single entry point for the engine. Calling it:
+
+      1. Inserts a user_violations row (points = severity weight).
+      2. Computes the decision using the rolling-window query.
+      3. Writes a mod_actions audit row tagged with test_mode.
+      4. Returns the decision for the caller (bot) to execute.
+    """
+    policy = await _load_policy()
+
+    # 1. Record the violation up front so it counts toward its own window lookup.
+    await discipline_repo.add_violation(
+        event_id=event_id,
+        guild_id=guild_id,
+        user_id=user_id,
+        category=category,
+        severity=severity,
+    )
+
+    # 2. Decide.
+    decision = await _decide(
+        guild_id=guild_id,
+        user_id=user_id,
+        category=category,
+        policy=policy,
+    )
+
+    # 3. Audit.
+    action_type = _action_type_for(decision.action)
+    if action_type is not None:
+        await discipline_repo.record_action(
+            event_id=event_id,
+            guild_id=guild_id,
+            user_id=user_id,
+            action_type=action_type,
+            actor="bot",
+            reason=decision.reason,
+            test_mode=decision.test_mode,
+            details=json.dumps(
+                {
+                    "points_total": decision.points_total,
+                    "window_days": decision.window_days,
+                    "ban_minutes": decision.ban_minutes,
+                }
+            ),
+        )
+
+    return decision
+
+
+async def _decide(
+    *,
+    guild_id: str,
+    user_id: str,
+    category: str,
+    policy: dict,
+) -> DisciplineDecision:
+    """Pure policy — no writes. Called after the violation row is inserted."""
+    window_days = policy["window_days"]
+    threshold = policy["threshold"]
+    test_mode = policy["test_mode"]
+    ban_minutes = policy["ban_minutes"]
+
+    # Rule 1: re-offense after kick → timed ban.
+    if await discipline_repo.has_kick_for_user(guild_id, user_id):
+        points_total = await discipline_repo.sum_points_in_window(
+            guild_id, user_id, window_days
+        )
+        return DisciplineDecision(
+            action=DisciplineAction.TIMED_BAN,
+            reason=(
+                f"Re-offense after kick — applying {ban_minutes}-minute ban"
+            ),
+            points_total=points_total,
+            window_days=window_days,
+            test_mode=test_mode,
+            ban_minutes=ban_minutes,
+        )
+
+    # Rule 2 & 3 share the window query.
+    points_total = await discipline_repo.sum_points_in_window(
+        guild_id, user_id, window_days
+    )
+
+    if points_total >= threshold:
+        return DisciplineDecision(
+            action=DisciplineAction.KICK,
+            reason=(
+                f"Severity-weighted points {points_total} ≥ threshold {threshold} "
+                f"in last {window_days} days"
+            ),
+            points_total=points_total,
+            window_days=window_days,
+            test_mode=test_mode,
+        )
+
+    if policy["repeat_category_kicks"]:
+        same_count = await discipline_repo.count_same_category_in_window(
+            guild_id, user_id, category, window_days
+        )
+        if same_count >= 2:
+            return DisciplineDecision(
+                action=DisciplineAction.KICK,
+                reason=(
+                    f"Repeat {category} violation — "
+                    f"{same_count} in last {window_days} days"
+                ),
+                points_total=points_total,
+                window_days=window_days,
+                test_mode=test_mode,
+            )
+
+    return DisciplineDecision(
+        action=DisciplineAction.WARN,
+        reason=(
+            f"First-tier violation — {points_total} point(s) in last "
+            f"{window_days} days"
+        ),
+        points_total=points_total,
+        window_days=window_days,
+        test_mode=test_mode,
+    )
+
+
+def _action_type_for(action: DisciplineAction) -> ModActionType | None:
+    """Map the engine output to the audit-log action type."""
+    mapping = {
+        DisciplineAction.WARN: ModActionType.WARN,
+        DisciplineAction.KICK: ModActionType.KICK,
+        DisciplineAction.TIMED_BAN: ModActionType.TIMED_BAN,
+    }
+    return mapping.get(action)
+
+
+async def undo_for_event(event_id: str, actor: str = "dashboard") -> dict:
+    """Revoke the discipline action attached to an event.
+
+    This is the implementation of the "Undo" button in the portal:
+
+      1. Look up the event's (guild_id, user_id) via moderation_repo.
+      2. Revoke every un-revoked violation for that user in that guild.
+         Design decision (PAM): reset the whole ledger, not just this one
+         row — it makes re-testing with a single Discord account trivial.
+      3. Mark the mod_actions rows linked to this event as undone.
+      4. Record an 'undo' action row so the audit trail is complete.
+
+    Returns a small summary dict for the API response.
+    """
+    # Late import — moderation_repo pulls schemas, and that module imports this
+    # one through services.__init__ in some orderings.
+    from repositories import moderation_repo  # noqa: PLC0415
+
+    event = await moderation_repo.get_by_id(event_id)
+    if event is None:
+        return {"undone": False, "reason": "event_not_found"}
+
+    guild_id = getattr(event, "discord_guild_id", None)
+    user_id = getattr(event, "discord_user_id", None)
+    if not guild_id or not user_id:
+        return {"undone": False, "reason": "no_discord_context"}
+
+    violations_revoked = await discipline_repo.revoke_all_for_user(
+        guild_id=guild_id, user_id=user_id
+    )
+    actions_marked = await discipline_repo.mark_actions_undone_for_event(event_id)
+
+    await discipline_repo.record_action(
+        event_id=event_id,
+        guild_id=guild_id,
+        user_id=user_id,
+        action_type=ModActionType.UNDO,
+        actor=actor,
+        reason="Moderator undo via dashboard",
+        test_mode=await settings_repo.get_bool("test_mode", False),
+    )
+
+    return {
+        "undone": True,
+        "violations_revoked": violations_revoked,
+        "actions_marked_undone": actions_marked,
+        "guild_id": guild_id,
+        "user_id": user_id,
+    }

--- a/backend/services/moderation_service.py
+++ b/backend/services/moderation_service.py
@@ -13,10 +13,15 @@ from models.enums import (
     TaskType,
     ViolationType,
 )
-from models.schemas import ModerationEventResponse
+from models.schemas import DisciplineDecisionPayload, ModerationEventResponse
 from prompts.moderation_prompt import get_system_prompt
 from repositories import moderation_repo, settings_repo
-from services import audit_service, provider_service, retrieval_service
+from services import (
+    audit_service,
+    discipline_service,
+    provider_service,
+    retrieval_service,
+)
 from services.utils import parse_json_response
 
 logger = logging.getLogger(__name__)
@@ -104,11 +109,16 @@ async def classify_only(text: str) -> ModerationLLMResult:
 async def analyze(
     message_content: str,
     source: EventSource,
+    *,
+    discord_user_id: str | None = None,
+    discord_guild_id: str | None = None,
 ) -> ModerationEventResponse:
-    """Run moderation analysis and persist the event.
+    """Run moderation analysis, persist the event, and return the decision.
 
-    Public API is unchanged — callers see the same ModerationEventResponse.
-    Internally the LLM call + JSON parse is now delegated to _run_moderation_llm.
+    Public API is extended (not broken) — callers that don't pass Discord
+    context still get a valid ModerationEventResponse, just without a
+    discipline_decision attached. Bot callers supply the Discord IDs so
+    the progressive-discipline engine can update the per-user ledger.
     """
     # 1-3. LLM call + parse (no persistence)
     llm_result = await _run_moderation_llm(message_content)
@@ -139,9 +149,33 @@ async def analyze(
         suggested_action=llm_result.suggested_action,
         status=status,
         source=source,
+        discord_user_id=discord_user_id,
+        discord_guild_id=discord_guild_id,
     )
 
-    # 6. Audit
+    # 6. Progressive discipline — only fires when the event is auto_actioned
+    # *and* we have Discord context to attribute it to. Dashboard-sourced
+    # /analyze calls from the Review Queue test box deliberately skip this.
+    decision_payload: DisciplineDecisionPayload | None = None
+    if (
+        status == ModerationStatus.AUTO_ACTIONED
+        and discord_user_id
+        and discord_guild_id
+    ):
+        decision = await discipline_service.decide_and_record(
+            event_id=event_id,
+            guild_id=discord_guild_id,
+            user_id=discord_user_id,
+            category=llm_result.violation_type.value,
+            severity=llm_result.severity,
+        )
+        await moderation_repo.set_discipline_action(event_id, decision.action.value)
+        event = event.model_copy(update={"discipline_action": decision.action})
+        decision_payload = DisciplineDecisionPayload(**decision.to_dict())
+
+    event = event.model_copy(update={"discipline_decision": decision_payload})
+
+    # 7. Audit
     await audit_service.log_interaction(
         task_type=TaskType.MODERATION.value,
         input_text=message_content,

--- a/backend/tests/test_discipline.py
+++ b/backend/tests/test_discipline.py
@@ -1,0 +1,256 @@
+"""Unit tests for the progressive-discipline engine.
+
+Exercises the decision tree branches end-to-end against a real (temp-file)
+SQLite DB:
+
+  - first violation  → WARN
+  - second same-category → KICK
+  - severity-weighted points >= threshold → KICK
+  - re-offense after kick → TIMED_BAN
+  - undo resets the ledger and marks prior action rows undone
+  - test_mode flag flows through to the audit row
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from database import init_db
+from models.enums import (
+    DisciplineAction,
+    EventSource,
+    ModerationStatus,
+    Severity,
+    SuggestedAction,
+    ViolationType,
+)
+from repositories import discipline_repo, moderation_repo, settings_repo
+from services import discipline_service
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def seeded_db(db_path, _patch_db):
+    """Initialise a fresh DB with the discipline defaults seeded."""
+    await init_db()
+    yield db_path
+
+
+GUILD = "10000000000000001"
+USER = "20000000000000001"
+
+
+async def _insert_event(
+    *,
+    event_id: str,
+    severity: Severity = Severity.MEDIUM,
+    violation: ViolationType = ViolationType.HARASSMENT,
+    guild_id: str = GUILD,
+    user_id: str = USER,
+    source: EventSource = EventSource.DISCORD,
+) -> str:
+    await moderation_repo.create(
+        event_id=event_id,
+        message_content="<test message>",
+        violation_type=violation,
+        matched_rule="Rule test",
+        explanation="testing",
+        severity=severity,
+        suggested_action=SuggestedAction.REMOVE_MESSAGE,
+        status=ModerationStatus.AUTO_ACTIONED,
+        source=source,
+        discord_user_id=user_id,
+        discord_guild_id=guild_id,
+    )
+    return event_id
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_violation_warns(seeded_db):
+    await _insert_event(event_id="ev1", severity=Severity.LOW)
+    decision = await discipline_service.decide_and_record(
+        event_id="ev1",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HARASSMENT.value,
+        severity=Severity.LOW,
+    )
+    assert decision.action == DisciplineAction.WARN
+    assert decision.points_total == 1  # low = 1 point
+    assert decision.test_mode is False
+
+
+@pytest.mark.asyncio
+async def test_second_same_category_kicks(seeded_db):
+    await _insert_event(event_id="ev1", severity=Severity.LOW)
+    d1 = await discipline_service.decide_and_record(
+        event_id="ev1",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HARASSMENT.value,
+        severity=Severity.LOW,
+    )
+    assert d1.action == DisciplineAction.WARN
+
+    await _insert_event(event_id="ev2", severity=Severity.LOW)
+    d2 = await discipline_service.decide_and_record(
+        event_id="ev2",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HARASSMENT.value,
+        severity=Severity.LOW,
+    )
+    assert d2.action == DisciplineAction.KICK
+    assert "Repeat harassment" in d2.reason
+
+
+@pytest.mark.asyncio
+async def test_severity_threshold_triggers_kick(seeded_db):
+    # A single CRITICAL severity violation (5 points) should hit the
+    # default threshold (5) on its own — no repeat required.
+    await _insert_event(event_id="evA", severity=Severity.CRITICAL)
+    decision = await discipline_service.decide_and_record(
+        event_id="evA",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HATE_SPEECH.value,
+        severity=Severity.CRITICAL,
+    )
+    assert decision.action == DisciplineAction.KICK
+    assert decision.points_total == 5
+    assert "threshold" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_reoffense_after_kick_bans(seeded_db):
+    # First: accumulate a critical violation → KICK
+    await _insert_event(event_id="evA", severity=Severity.CRITICAL)
+    kick = await discipline_service.decide_and_record(
+        event_id="evA",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HATE_SPEECH.value,
+        severity=Severity.CRITICAL,
+    )
+    assert kick.action == DisciplineAction.KICK
+
+    # Second: same user offends again → TIMED_BAN (regardless of category/severity)
+    await _insert_event(event_id="evB", severity=Severity.LOW)
+    ban = await discipline_service.decide_and_record(
+        event_id="evB",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.SPAM.value,
+        severity=Severity.LOW,
+    )
+    assert ban.action == DisciplineAction.TIMED_BAN
+    assert ban.ban_minutes == 60  # default
+
+
+@pytest.mark.asyncio
+async def test_undo_resets_ledger(seeded_db):
+    """Undo should revoke all violations and mark the kick row undone."""
+    await _insert_event(event_id="evA", severity=Severity.CRITICAL)
+    await discipline_service.decide_and_record(
+        event_id="evA",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HATE_SPEECH.value,
+        severity=Severity.CRITICAL,
+    )
+
+    # Sanity: kick is on record
+    assert await discipline_repo.has_kick_for_user(GUILD, USER) is True
+
+    result = await discipline_service.undo_for_event("evA")
+    assert result["undone"] is True
+    assert result["violations_revoked"] >= 1
+    assert result["actions_marked_undone"] >= 1
+
+    # Ledger should now be empty and no active kick
+    assert await discipline_repo.sum_points_in_window(GUILD, USER, 30) == 0
+    assert await discipline_repo.has_kick_for_user(GUILD, USER) is False
+
+
+@pytest.mark.asyncio
+async def test_undo_missing_event_returns_reason(seeded_db):
+    result = await discipline_service.undo_for_event("nonexistent")
+    assert result == {"undone": False, "reason": "event_not_found"}
+
+
+@pytest.mark.asyncio
+async def test_undo_no_discord_context_returns_reason(seeded_db):
+    # Dashboard-sourced event with no Discord IDs — nothing to undo against.
+    await moderation_repo.create(
+        event_id="dash1",
+        message_content="<test>",
+        violation_type=ViolationType.HARASSMENT,
+        matched_rule=None,
+        explanation="x",
+        severity=Severity.LOW,
+        suggested_action=SuggestedAction.REMOVE_MESSAGE,
+        status=ModerationStatus.AUTO_ACTIONED,
+        source=EventSource.DASHBOARD,
+    )
+    result = await discipline_service.undo_for_event("dash1")
+    assert result == {"undone": False, "reason": "no_discord_context"}
+
+
+@pytest.mark.asyncio
+async def test_test_mode_flag_is_recorded(seeded_db):
+    await settings_repo.set("test_mode", "true")
+    await _insert_event(event_id="ev1", severity=Severity.LOW)
+    decision = await discipline_service.decide_and_record(
+        event_id="ev1",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HARASSMENT.value,
+        severity=Severity.LOW,
+    )
+    assert decision.test_mode is True
+
+    # The recorded mod_actions row should carry test_mode=1
+    async with aiosqlite.connect(seeded_db) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT test_mode FROM mod_actions WHERE event_id = 'ev1'"
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row["test_mode"] == 1
+
+
+@pytest.mark.asyncio
+async def test_repeat_category_policy_can_be_disabled(seeded_db):
+    await settings_repo.set("discipline_repeat_category_kicks", "false")
+
+    await _insert_event(event_id="ev1", severity=Severity.LOW)
+    d1 = await discipline_service.decide_and_record(
+        event_id="ev1",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HARASSMENT.value,
+        severity=Severity.LOW,
+    )
+    assert d1.action == DisciplineAction.WARN
+
+    await _insert_event(event_id="ev2", severity=Severity.LOW)
+    d2 = await discipline_service.decide_and_record(
+        event_id="ev2",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HARASSMENT.value,
+        severity=Severity.LOW,
+    )
+    # Two points total, threshold still 5 — should still WARN, not KICK
+    assert d2.action == DisciplineAction.WARN

--- a/backend/tests/test_discipline.py
+++ b/backend/tests/test_discipline.py
@@ -231,6 +231,46 @@ async def test_test_mode_flag_is_recorded(seeded_db):
 
 
 @pytest.mark.asyncio
+async def test_test_mode_kick_does_not_escalate_after_flip(seeded_db):
+    """A test-mode (simulated) kick must not trigger a real timed-ban later.
+
+    Regression: has_kick_for_user used to look at every non-undone kick row,
+    so dry-run runs in test mode would poison the reoffense lookup once
+    test mode was turned off.
+    """
+    # Test mode ON: first violation escalates to a (simulated) KICK.
+    await settings_repo.set("test_mode", "true")
+    await _insert_event(event_id="ev_sim", severity=Severity.CRITICAL)
+    sim = await discipline_service.decide_and_record(
+        event_id="ev_sim",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.HATE_SPEECH.value,
+        severity=Severity.CRITICAL,
+    )
+    assert sim.action == DisciplineAction.KICK
+    assert sim.test_mode is True
+
+    # Flip test mode OFF. Next offense should NOT see the simulated kick.
+    await settings_repo.set("test_mode", "false")
+    assert await discipline_repo.has_kick_for_user(GUILD, USER) is False
+
+    # Undo the first simulated ledger so we can observe a clean WARN path.
+    await discipline_service.undo_for_event("ev_sim")
+
+    await _insert_event(event_id="ev_real", severity=Severity.LOW)
+    real = await discipline_service.decide_and_record(
+        event_id="ev_real",
+        guild_id=GUILD,
+        user_id=USER,
+        category=ViolationType.SPAM.value,
+        severity=Severity.LOW,
+    )
+    # Without the test-mode-aware filter this would be TIMED_BAN.
+    assert real.action == DisciplineAction.WARN
+
+
+@pytest.mark.asyncio
 async def test_repeat_category_policy_can_be_disabled(seeded_db):
     await settings_repo.set("discipline_repeat_category_kicks", "false")
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -63,3 +63,65 @@ def test_demo_mode_response_shape(client):
     data = client.get("/api/settings/demo-mode").json()
     assert "demo_mode" in data
     assert isinstance(data["demo_mode"], bool)
+
+
+# ---------------------------------------------------------------------------
+# Generic settings CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_settings_returns_allow_list(client):
+    """GET /api/settings surfaces every allow-listed key with seeded defaults."""
+    response = client.get("/api/settings")
+    assert response.status_code == 200
+
+    settings = response.json()["settings"]
+    # Seeded defaults that should be present
+    assert settings["demo_mode"] == "true"
+    assert settings["test_mode"] == "false"
+    assert settings["discipline_points_threshold"] == "5"
+    assert settings["discipline_window_days"] == "30"
+    assert settings["discipline_repeat_category_kicks"] == "true"
+    assert settings["discipline_ban_minutes"] == "60"
+    # chat_enabled is seeded on-demand by the /chat-enabled POST, so its key
+    # must exist (falls back to "") and never error.
+    assert "chat_enabled" in settings
+
+
+def test_post_settings_updates_multiple_keys(client):
+    """POST /api/settings persists a batch of settings and echoes the new state."""
+    response = client.post(
+        "/api/settings",
+        json={
+            "updates": {
+                "test_mode": "true",
+                "discipline_points_threshold": "8",
+                "discipline_ban_minutes": "120",
+            }
+        },
+    )
+    assert response.status_code == 200
+    settings = response.json()["settings"]
+    assert settings["test_mode"] == "true"
+    assert settings["discipline_points_threshold"] == "8"
+    assert settings["discipline_ban_minutes"] == "120"
+    # Untouched keys preserved
+    assert settings["demo_mode"] == "true"
+
+
+def test_post_settings_rejects_unknown_key(client):
+    """Keys outside the allow-list are rejected with 422."""
+    response = client.post(
+        "/api/settings",
+        json={"updates": {"OPENAI_API_KEY": "leaked"}},
+    )
+    assert response.status_code == 422
+
+
+def test_post_settings_rejects_secret_key(client):
+    """Secret keys must never be writeable through the generic endpoint."""
+    response = client.post(
+        "/api/settings",
+        json={"updates": {"DISCORD_TOKEN": "leaked"}},
+    )
+    assert response.status_code == 422

--- a/bot/api_client.py
+++ b/bot/api_client.py
@@ -44,12 +44,30 @@ class BackendClient:
         """Draft a moderator response for a given situation."""
         return await self._post("/api/moderation/draft", {"situation": situation})
 
-    async def analyze(self, message_content: str, source: str = "discord") -> dict:
-        """Run moderation analysis on a message."""
-        return await self._post(
-            "/api/moderation/analyze",
-            {"message_content": message_content, "source": source},
-        )
+    async def analyze(
+        self,
+        message_content: str,
+        source: str = "discord",
+        *,
+        discord_user_id: str | None = None,
+        discord_guild_id: str | None = None,
+    ) -> dict:
+        """Run moderation analysis on a message.
+
+        Discord IDs are forwarded so the backend's progressive-discipline
+        engine can update the per-user ledger. Omitting them yields the
+        legacy behaviour: an event is created but no discipline action
+        is evaluated.
+        """
+        payload: dict[str, Any] = {
+            "message_content": message_content,
+            "source": source,
+        }
+        if discord_user_id is not None:
+            payload["discord_user_id"] = discord_user_id
+        if discord_guild_id is not None:
+            payload["discord_guild_id"] = discord_guild_id
+        return await self._post("/api/moderation/analyze", payload)
 
     async def get_demo_mode(self) -> bool:
         """Return the current demo-mode flag."""

--- a/bot/cogs/monitor.py
+++ b/bot/cogs/monitor.py
@@ -163,18 +163,25 @@ class MonitorCog(commands.Cog):
             )
             return "Would have kicked"
 
-        member = message.guild.get_member(message.author.id) if message.guild else None
-        if member is None:
-            log.warning("Kick target %s not found in guild cache", message.author.id)
-            return "Kick skipped (target not in guild)"
+        if message.guild is None:
+            log.warning("Kick skipped — message has no guild context")
+            return "Kick skipped (no guild)"
+
+        # Members intent is not enabled, so the member cache is always cold;
+        # fall back to the message author (any Snowflake works with Guild.kick).
+        member = message.guild.get_member(message.author.id)
+        target: discord.abc.Snowflake = member or message.author
         try:
-            await member.kick(reason=reason or "Progressive discipline: kick")
+            await message.guild.kick(
+                target,
+                reason=reason or "Progressive discipline: kick",
+            )
             return "User kicked"
         except discord.Forbidden:
-            log.warning("Missing permissions to kick %s", member.id)
+            log.warning("Missing permissions to kick %s", message.author.id)
             return "Kick skipped (missing permission)"
         except discord.HTTPException as exc:
-            log.warning("Kick failed for %s: %s", member.id, exc)
+            log.warning("Kick failed for %s: %s", message.author.id, exc)
             return "Kick failed"
 
     async def _timed_ban_member(

--- a/bot/cogs/monitor.py
+++ b/bot/cogs/monitor.py
@@ -66,39 +66,160 @@ class MonitorCog(commands.Cog):
 
         client = BackendClient(self.bot.http_session)
 
-        # 1. Run analysis
-        data = await client.analyze(message.content, source="discord")
+        guild_id = str(message.guild.id) if message.guild is not None else None
+        user_id = str(message.author.id)
+
+        # 1. Run analysis — forward Discord context so the backend's
+        #    progressive-discipline engine can update the per-user ledger.
+        data = await client.analyze(
+            message.content,
+            source="discord",
+            discord_user_id=user_id,
+            discord_guild_id=guild_id,
+        )
 
         # 2. Ignore clean messages
         if data.get("suggested_action") == "no_action":
             return
 
-        # 3. Backend already decided demo-mode action — trust the status field.
-        #    (moderation_service.analyze sets status=auto_actioned when demo_mode
-        #    is on AND the action is one of the auto-delete triggers.)
+        # 3. Backend decided auto_actioned — delete + apply discipline.
         if data.get("status") == "auto_actioned":
-            try:
-                await message.delete()
-            except discord.Forbidden:
-                log.warning(
-                    "Missing permissions to delete message %s in #%s",
-                    message.id,
-                    message.channel,
-                )
-            except discord.NotFound:
-                log.debug("Message %s already deleted", message.id)
+            await self._delete_message(message)
+            await self._apply_discipline(message, data)
+            return
 
+        # 4. Non-auto path: just alert mods for medium/high/critical severity.
+        severity = data.get("severity", "")
+        if severity in ("medium", "high", "critical"):
             embed = build_moderation_alert(data, message)
-            embed.set_footer(text="Message auto-deleted (demo mode)")
+            embed.set_footer(text="Pending moderator review — check dashboard")
             await message.channel.send(embed=embed)
 
-        else:
-            # Non-demo: alert for medium/high/critical severity
-            severity = data.get("severity", "")
-            if severity in ("medium", "high", "critical"):
-                embed = build_moderation_alert(data, message)
-                embed.set_footer(text="Pending moderator review — check dashboard")
-                await message.channel.send(embed=embed)
+    # ── action pipeline ───────────────────────────────────────────────
+
+    async def _delete_message(self, message: discord.Message) -> None:
+        """Swallow expected failure modes so the pipeline continues."""
+        try:
+            await message.delete()
+        except discord.Forbidden:
+            log.warning(
+                "Missing permissions to delete message %s in #%s",
+                message.id,
+                message.channel,
+            )
+        except discord.NotFound:
+            log.debug("Message %s already deleted", message.id)
+
+    async def _apply_discipline(
+        self,
+        message: discord.Message,
+        data: dict,
+    ) -> None:
+        """Execute the backend's discipline decision and post an alert embed.
+
+        Test mode: still emits the alert embed so mods can see what *would*
+        have happened, but skips the actual member.kick/ban call.
+        """
+        decision = data.get("discipline_decision") or {}
+        action = decision.get("action", "none")
+        test_mode = bool(decision.get("test_mode"))
+
+        executed: str | None = None
+        if action == "warn":
+            executed = "Warned"
+        elif action == "kick":
+            executed = await self._kick_member(message, reason=decision.get("reason"), test_mode=test_mode)
+        elif action == "timed_ban":
+            executed = await self._timed_ban_member(
+                message,
+                reason=decision.get("reason"),
+                ban_minutes=decision.get("ban_minutes"),
+                test_mode=test_mode,
+            )
+        # action == 'none' or missing: just fall through to the alert
+
+        embed = build_moderation_alert(data, message)
+        footer_parts = ["Message auto-deleted (demo mode)"]
+        if executed:
+            footer_parts.append(executed)
+        if test_mode:
+            footer_parts.append("TEST MODE — no real Discord action")
+        embed.set_footer(text=" · ".join(footer_parts))
+        await message.channel.send(embed=embed)
+
+    async def _kick_member(
+        self,
+        message: discord.Message,
+        *,
+        reason: str | None,
+        test_mode: bool,
+    ) -> str:
+        if test_mode:
+            log.info(
+                "TEST MODE kick would target user=%s in guild=%s reason=%r",
+                message.author.id,
+                getattr(message.guild, "id", None),
+                reason,
+            )
+            return "Would have kicked"
+
+        member = message.guild.get_member(message.author.id) if message.guild else None
+        if member is None:
+            log.warning("Kick target %s not found in guild cache", message.author.id)
+            return "Kick skipped (target not in guild)"
+        try:
+            await member.kick(reason=reason or "Progressive discipline: kick")
+            return "User kicked"
+        except discord.Forbidden:
+            log.warning("Missing permissions to kick %s", member.id)
+            return "Kick skipped (missing permission)"
+        except discord.HTTPException as exc:
+            log.warning("Kick failed for %s: %s", member.id, exc)
+            return "Kick failed"
+
+    async def _timed_ban_member(
+        self,
+        message: discord.Message,
+        *,
+        reason: str | None,
+        ban_minutes: int | None,
+        test_mode: bool,
+    ) -> str:
+        """Issue a ban; auto-unban handling is left to a follow-up PR.
+
+        For now the embed footer advertises the duration so a moderator can
+        lift the ban manually via the portal's Undo button. A scheduled
+        unban worker is out of scope for this commit — the ban is real,
+        the lift is a moderator action.
+        """
+        label = f"{ban_minutes}-minute ban" if ban_minutes else "Timed ban"
+
+        if test_mode:
+            log.info(
+                "TEST MODE %s would target user=%s in guild=%s reason=%r",
+                label,
+                message.author.id,
+                getattr(message.guild, "id", None),
+                reason,
+            )
+            return f"Would have issued {label}"
+
+        member = message.guild.get_member(message.author.id) if message.guild else None
+        target: discord.abc.Snowflake | None = member or message.author
+        try:
+            # Passing a User object still works — discord.py accepts anything with an `.id`.
+            await message.guild.ban(
+                target,
+                reason=reason or f"Progressive discipline: {label}",
+                delete_message_days=0,
+            )
+            return f"User banned ({label})"
+        except discord.Forbidden:
+            log.warning("Missing permissions to ban %s", message.author.id)
+            return "Ban skipped (missing permission)"
+        except discord.HTTPException as exc:
+            log.warning("Ban failed for %s: %s", message.author.id, exc)
+            return "Ban failed"
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -95,4 +95,17 @@ def build_moderation_alert(
             name="Action", value=data["suggested_action"], inline=True
         )
 
+    decision = data.get("discipline_decision")
+    if decision:
+        action = str(decision.get("action", "")).replace("_", " ")
+        reason = decision.get("reason", "")
+        label = "Discipline"
+        if decision.get("test_mode"):
+            label = "Discipline (test mode — no Discord action taken)"
+        value = _truncate(
+            f"**{action.upper()}** — {reason}" if reason else f"**{action.upper()}**",
+            1024,
+        )
+        embed.add_field(name=label, value=value, inline=False)
+
     return embed

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -95,3 +95,21 @@ export function getHistory(limit = 50, offset = 0, status) {
   }
   return request(url);
 }
+
+export function getAllSettings() {
+  return request("/api/settings");
+}
+
+export function updateSettings(updates) {
+  return request("/api/settings", {
+    method: "POST",
+    body: JSON.stringify({ updates }),
+  });
+}
+
+export function undoDisciplineForEvent(eventId) {
+  return request(`/api/moderation/undo/${encodeURIComponent(eventId)}`, {
+    method: "POST",
+    body: JSON.stringify({}),
+  });
+}

--- a/frontend/src/components/ModerationHistory.css
+++ b/frontend/src/components/ModerationHistory.css
@@ -202,3 +202,47 @@
   min-width: 130px;
   flex-shrink: 0;
 }
+
+.moderation-history__undo {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.moderation-history__undo-btn {
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--color-severity-critical);
+  border: 1px solid var(--color-severity-critical);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: filter 150ms ease;
+}
+
+.moderation-history__undo-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.moderation-history__undo-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.moderation-history__undo-msg {
+  font-size: 13px;
+  color: var(--color-text);
+}
+
+.moderation-history__undo-hint {
+  flex-basis: 100%;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+  margin: 0;
+}

--- a/frontend/src/components/ModerationHistory.jsx
+++ b/frontend/src/components/ModerationHistory.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { getHistory } from "../api.js";
+import { getHistory, undoDisciplineForEvent } from "../api.js";
 import SeverityBadge from "./shared/SeverityBadge.jsx";
 import RuleMatchChip from "./shared/RuleMatchChip.jsx";
 import { formatEnumValue } from "../utils/formatEnum.js";
@@ -50,6 +50,8 @@ export default function ModerationHistory() {
   const [error, setError] = useState(null);
   const [activeFilter, setActiveFilter] = useState("all");
   const [expandedId, setExpandedId] = useState(null);
+  const [undoing, setUndoing] = useState(null);
+  const [undoMsg, setUndoMsg] = useState({});
 
   const fetchHistory = useCallback(async () => {
     setLoading(true);
@@ -76,6 +78,27 @@ export default function ModerationHistory() {
 
   const toggleExpand = (eventId) => {
     setExpandedId(expandedId === eventId ? null : eventId);
+  };
+
+  const handleUndo = async (eventId) => {
+    setUndoing(eventId);
+    setUndoMsg((m) => ({ ...m, [eventId]: "" }));
+    try {
+      const res = await undoDisciplineForEvent(eventId);
+      const msg = res.reason
+        ? `Undo: ${res.reason}`
+        : `Undone (${res.violations_revoked ?? 0} violations revoked, ${res.actions_marked_undone ?? 0} actions marked)`;
+      setUndoMsg((m) => ({ ...m, [eventId]: msg }));
+      // Refresh to pick up any backend-side state changes
+      fetchHistory();
+    } catch (err) {
+      setUndoMsg((m) => ({
+        ...m,
+        [eventId]: err.message || "Undo failed",
+      }));
+    } finally {
+      setUndoing(null);
+    }
   };
 
   return (
@@ -230,6 +253,40 @@ export default function ModerationHistory() {
                     </span>
                     <span>{formatTimestamp(event.resolved_at)}</span>
                   </div>
+                  {event.discipline_action && event.discipline_action !== "none" && (
+                    <div className="moderation-history__detail-row">
+                      <span className="moderation-history__detail-label">
+                        Discipline:
+                      </span>
+                      <span>{formatEnumValue(event.discipline_action)}</span>
+                    </div>
+                  )}
+                  {event.status === "auto_actioned" &&
+                    event.discord_user_id &&
+                    event.discipline_action &&
+                    event.discipline_action !== "none" && (
+                      <div className="moderation-history__undo">
+                        <button
+                          className="moderation-history__undo-btn"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleUndo(event.event_id);
+                          }}
+                          disabled={undoing === event.event_id}
+                        >
+                          {undoing === event.event_id ? "Undoing…" : "Undo discipline"}
+                        </button>
+                        {undoMsg[event.event_id] && (
+                          <span className="moderation-history__undo-msg">
+                            {undoMsg[event.event_id]}
+                          </span>
+                        )}
+                        <p className="moderation-history__undo-hint">
+                          Revokes this user's violation points and marks the kick/ban as undone.
+                          Any active Discord ban must be lifted manually in the server.
+                        </p>
+                      </div>
+                    )}
                 </div>
               )}
             </div>

--- a/frontend/src/components/Settings.css
+++ b/frontend/src/components/Settings.css
@@ -118,3 +118,91 @@
 .settings__stat-value--warn {
   color: var(--color-severity-critical);
 }
+
+.settings__row--stacked {
+  margin-top: 16px;
+}
+
+.settings__grid--inputs {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  margin-top: 20px;
+}
+
+.settings__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings__field-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.settings__field-hint {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.settings__input {
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.settings__input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.settings__input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.settings__actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--color-border);
+}
+
+.settings__save-btn {
+  padding: 8px 20px;
+  border-radius: 6px;
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.settings__save-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.settings__save-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.settings__save-msg {
+  font-size: 13px;
+}
+
+.settings__save-msg--ok {
+  color: var(--color-approved);
+}
+
+.settings__save-msg--err {
+  color: var(--color-severity-critical);
+}

--- a/frontend/src/components/Settings.jsx
+++ b/frontend/src/components/Settings.jsx
@@ -1,24 +1,47 @@
 import { useState, useEffect } from "react";
-import { healthCheck, getDemoMode, setDemoMode } from "../api.js";
+import {
+  healthCheck,
+  getDemoMode,
+  setDemoMode,
+  getAllSettings,
+  updateSettings,
+} from "../api.js";
 import "./Settings.css";
+
+// Integer fields and their validation bounds
+const INT_FIELDS = {
+  discipline_points_threshold: { min: 1, max: 100 },
+  discipline_window_days: { min: 1, max: 365 },
+  discipline_ban_minutes: { min: 1, max: 43200 }, // up to 30 days
+};
+
+function asBool(v) {
+  return v === "true" || v === true;
+}
 
 export default function Settings() {
   const [health, setHealth] = useState(null);
   const [demoMode, setDemoModeState] = useState(false);
-  const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
 
+  const [settings, setSettings] = useState(null);
+  const [dirty, setDirty] = useState({});
+  const [saving, setSaving] = useState(false);
+  const [saveMsg, setSaveMsg] = useState("");
+  const [loading, setLoading] = useState(true);
+
   useEffect(() => {
-    Promise.all([healthCheck(), getDemoMode()])
-      .then(([h, d]) => {
+    Promise.all([healthCheck(), getDemoMode(), getAllSettings()])
+      .then(([h, d, s]) => {
         setHealth(h);
         setDemoModeState(d.demo_mode);
+        setSettings(s.settings);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 
-  const handleToggle = async () => {
+  const handleToggleDemo = async () => {
     setToggling(true);
     try {
       const res = await setDemoMode(!demoMode);
@@ -29,6 +52,50 @@ export default function Settings() {
       setToggling(false);
     }
   };
+
+  const currentValue = (key) => {
+    if (key in dirty) return dirty[key];
+    return settings?.[key] ?? "";
+  };
+
+  const setField = (key, value) => {
+    setDirty((d) => ({ ...d, [key]: value }));
+    setSaveMsg("");
+  };
+
+  const validate = () => {
+    for (const [key, { min, max }] of Object.entries(INT_FIELDS)) {
+      if (!(key in dirty)) continue;
+      const raw = dirty[key];
+      const n = Number(raw);
+      if (!Number.isInteger(n) || n < min || n > max) {
+        return `${key} must be an integer between ${min} and ${max}`;
+      }
+    }
+    return null;
+  };
+
+  const handleSave = async () => {
+    const err = validate();
+    if (err) {
+      setSaveMsg(err);
+      return;
+    }
+    setSaving(true);
+    setSaveMsg("");
+    try {
+      const res = await updateSettings(dirty);
+      setSettings(res.settings);
+      setDirty({});
+      setSaveMsg("Saved.");
+    } catch (e) {
+      setSaveMsg(e.message || "Save failed.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasChanges = Object.keys(dirty).length > 0;
 
   if (loading) {
     return <div className="settings"><p className="settings__loading">Loading settings...</p></div>;
@@ -50,13 +117,117 @@ export default function Settings() {
           </div>
           <button
             className={`settings__toggle ${demoMode ? "settings__toggle--on" : ""}`}
-            onClick={handleToggle}
+            onClick={handleToggleDemo}
             disabled={toggling}
           >
             {demoMode ? "ON" : "OFF"}
           </button>
         </div>
       </div>
+
+      {settings && (
+        <div className="settings__section">
+          <h3 className="settings__section-title">Progressive Discipline</h3>
+
+          <div className="settings__row">
+            <div className="settings__row-info">
+              <p className="settings__label">Test Mode</p>
+              <p className="settings__description">
+                Dry-run — discipline decisions are recorded and surfaced in alerts, but
+                no kick or ban is sent to Discord. Useful for verifying policy changes.
+              </p>
+            </div>
+            <button
+              className={`settings__toggle ${asBool(currentValue("test_mode")) ? "settings__toggle--on" : ""}`}
+              onClick={() => setField("test_mode", asBool(currentValue("test_mode")) ? "false" : "true")}
+              disabled={saving}
+            >
+              {asBool(currentValue("test_mode")) ? "ON" : "OFF"}
+            </button>
+          </div>
+
+          <div className="settings__row settings__row--stacked">
+            <div className="settings__row-info">
+              <p className="settings__label">Repeat-category kicks</p>
+              <p className="settings__description">
+                Kick a user on a second offense in the same rule category within the
+                rolling window, even if their point total is below the threshold.
+              </p>
+            </div>
+            <button
+              className={`settings__toggle ${asBool(currentValue("discipline_repeat_category_kicks")) ? "settings__toggle--on" : ""}`}
+              onClick={() => setField(
+                "discipline_repeat_category_kicks",
+                asBool(currentValue("discipline_repeat_category_kicks")) ? "false" : "true",
+              )}
+              disabled={saving}
+            >
+              {asBool(currentValue("discipline_repeat_category_kicks")) ? "ON" : "OFF"}
+            </button>
+          </div>
+
+          <div className="settings__grid settings__grid--inputs">
+            <label className="settings__field">
+              <span className="settings__field-label">Points threshold (kick)</span>
+              <input
+                className="settings__input"
+                type="number"
+                min="1"
+                max="100"
+                value={currentValue("discipline_points_threshold")}
+                onChange={(e) => setField("discipline_points_threshold", e.target.value)}
+                disabled={saving}
+              />
+              <span className="settings__field-hint">Severity points: low=1, med=2, high=3, crit=5</span>
+            </label>
+
+            <label className="settings__field">
+              <span className="settings__field-label">Rolling window (days)</span>
+              <input
+                className="settings__input"
+                type="number"
+                min="1"
+                max="365"
+                value={currentValue("discipline_window_days")}
+                onChange={(e) => setField("discipline_window_days", e.target.value)}
+                disabled={saving}
+              />
+              <span className="settings__field-hint">Older violations decay out of the ledger</span>
+            </label>
+
+            <label className="settings__field">
+              <span className="settings__field-label">Timed ban (minutes)</span>
+              <input
+                className="settings__input"
+                type="number"
+                min="1"
+                max="43200"
+                value={currentValue("discipline_ban_minutes")}
+                onChange={(e) => setField("discipline_ban_minutes", e.target.value)}
+                disabled={saving}
+              />
+              <span className="settings__field-hint">Applied when a kicked user re-offends</span>
+            </label>
+          </div>
+
+          <div className="settings__actions">
+            <button
+              className="settings__save-btn"
+              onClick={handleSave}
+              disabled={!hasChanges || saving}
+            >
+              {saving ? "Saving…" : "Save changes"}
+            </button>
+            {saveMsg && (
+              <span
+                className={`settings__save-msg ${saveMsg === "Saved." ? "settings__save-msg--ok" : "settings__save-msg--err"}`}
+              >
+                {saveMsg}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
 
       {health && (
         <div className="settings__section">


### PR DESCRIPTION
## Summary

Progressive discipline engine: severity-weighted points (low=1/med=2/high=3/crit=5) over a rolling window trigger warn → kick → timed-ban decisions. Policy lives in the backend (single source of truth, testable); the bot executes via Discord API.

### Backend (commits 1–2)
- **Data model** (`fbc70d5`): `user_violations` + `mod_actions` tables, `ALTER TABLE` migration adds `discord_user_id`/`discord_guild_id`/`discipline_action` to `moderation_events`. Composite index on `(discord_guild_id, discord_user_id)` for ledger lookups.
- **Engine + routes** (`35dcc96`): `discipline_service.decide_and_record` with 4-rule tree — re-offense after kick → ban; threshold met → kick; repeat-category → kick; else warn. `POST /api/moderation/undo/{event_id}` revokes the user's full ledger and marks actions undone. 9 new tests cover every branch, including test-mode and undo.
- **Settings CRUD** (`b8ad059`): `GET`/`POST /api/settings` with a `WRITEABLE_SETTINGS_KEYS` allow-list — secrets are structurally unreachable. 4 new tests.

### Bot (commit 3)
- **Execution** (`09aab4e`): `monitor.py` forwards Discord IDs to `/analyze`, consumes `discipline_decision` from the response, and dispatches warn/kick/timed_ban. `test_mode` short-circuits to a log line without touching Discord. Embed footer reports what would / did happen.

### Portal (commits 4–5)
- **Settings page** (`511d49b`): Progressive Discipline card with Test Mode toggle, repeat-category toggle, and number inputs for points threshold, window days, ban minutes.
- **Undo UI** (`ccd93ad`): Expanded history row on auto-actioned events shows `discipline_action` and an Undo button (when Discord context exists). Hint reminds mods to lift active Discord bans manually.

### Deferred
- Auto-unban worker for timed bans — currently a mod action via Undo.

## Test plan
- [x] Backend: `python -m pytest backend/tests/ -q` — **311 passed**
- [x] Bot: `python -m pytest bot/tests/ -q` — **52 passed**
- [x] Frontend: `npm run build` — clean
- [ ] Manual: spin up the stack, send a low-severity message → warn, repeat same category → kick, re-offend → timed ban, click Undo → ledger resets
- [ ] Manual: flip Test Mode in Settings, verify no real kick/ban hits Discord
- [ ] Manual: try to POST an unknown settings key → expect 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)