### PR TITLE
fix(chat): seed chat_enabled=true so @-mentions aren't silently dropped

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -182,6 +182,11 @@ async def init_db() -> None:
             ("discipline_window_days", "30"),
             ("discipline_repeat_category_kicks", "true"),
             ("discipline_ban_minutes", "60"),
+            # Seed chat_enabled=true so the ChatCog DB kill-switch doesn't
+            # silently drop every @-mention on a fresh DB. The env-level
+            # CHAT_ENABLED gate still runs first — this row only controls
+            # the runtime toggle surfaced via /toggle-chat.
+            ("chat_enabled", "true"),
         ]
         for key, value in _DEFAULT_SETTINGS:
             await db.execute(

--- a/backend/tests/test_chat_route.py
+++ b/backend/tests/test_chat_route.py
@@ -161,9 +161,12 @@ def test_chat_missing_field_returns_422(client):
 # ---------------------------------------------------------------------------
 
 def test_chat_settings_get_default(client):
+    # init_db seeds chat_enabled=true so the ChatCog DB kill-switch doesn't
+    # silently drop every @-mention on a fresh DB. The env-level CHAT_ENABLED
+    # gate still runs first; this row controls the runtime /toggle-chat toggle.
     resp = client.get("/api/settings/chat-enabled")
     assert resp.status_code == 200
-    assert resp.json()["chat_enabled"] is False
+    assert resp.json()["chat_enabled"] is True
 
 
 def test_chat_settings_toggle(client):


### PR DESCRIPTION
## Summary

The ChatCog runs a DB-backed kill-switch check (`GET /api/settings/chat-enabled`) before forwarding `@ModBot` mentions to the backend. On a fresh DB the row is missing, so the endpoint returns `False` and every mention is silently dropped — the env-level `CHAT_ENABLED=true` alone is not sufficient because the route only consults the DB.

Caught in manual smoke-testing: `@ModBot hello` in the sandbox channel produced no reply, but backend logs showed `GET /api/settings/chat-enabled` firing and returning false. Seeding the row fixes it.

## Changes

- `backend/database.py` — add `("chat_enabled", "true")` to `_DEFAULT_SETTINGS`. Inline comment notes the env gate still runs first.
- `backend/tests/test_chat_route.py::test_chat_settings_get_default` — the old test asserted the missing-row default (`False`); update to match the new seeded default (`True`).

## Test plan

- [x] `python -m pytest backend/tests/ -q` — **312 passed**
- [x] Manual: after seeding the live DB and waiting for the cog's 30 s kill-switch cache to expire, `@ModBot` triggers `POST /api/chat` and the bot replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)