### PR TITLE
fix(a11y): darken --gradient-primary so white text passes WCAG AA

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,8 +56,11 @@
     0 1px 0 rgba(255, 255, 255, 0.05) inset,
     0 24px 48px -12px rgba(0, 0, 0, 0.4);
 
-  /* Gradient & glow — for accents / active pill / focus glow */
-  --gradient-primary: linear-gradient(135deg, #10b981 0%, #14b8a6 100%);
+  /* Gradient & glow — for accents / active pill / focus glow.
+     Uses emerald-700 → teal-700 (not the brighter -500 shades) so that
+     #ffffff text layered on top meets WCAG AA 4.5:1 contrast. The -500
+     pair measured 2.54:1 and failed AA for both text and non-text UI. */
+  --gradient-primary: linear-gradient(135deg, #047857 0%, #0f766e 100%);
   --gradient-accent: linear-gradient(135deg, rgba(16, 185, 129, 0.9) 0%, rgba(20, 184, 166, 0.7) 100%);
   --glow-primary: 0 0 0 1px rgba(16, 185, 129, 0.45), 0 6px 18px -6px rgba(16, 185, 129, 0.55);
 


### PR DESCRIPTION
## Summary

- Shifts the global `--gradient-primary` token from emerald-500 → teal-500 (`#10b981 → #14b8a6`) to emerald-700 → teal-700 (`#047857 → #0f766e`).
- Fixes a 2.54:1 contrast regression introduced in the PR 1 foundation. White text on the previous gradient failed WCAG AA for both text (4.5:1) and non-text UI components (3:1). The new gradient measures ~5.45:1 at its lightest point.
- One-line token change — fixes all seven use sites in one go (sidebar active item, KB filter pill, history filter active, Settings save button, PromptInput submit, App.css cta, index.css primary-button).

## Why a global token change

Every site that uses `--gradient-primary` layers `color: #ffffff` on top, so every site had the same contrast failure. A per-site override would have been seven near-identical patches; changing the token once is the minimum-diff fix. Sites that use `--color-primary` (as text on a dark surface) are unaffected — that value was already ~7.6:1.

## Visual note

The accent reads as a deeper evergreen instead of the previous brighter mint. The brand still registers as green-teal; the change is a saturation/luminance shift, not a hue shift. A before/after screenshot pair is straightforward to add if reviewers want it.

## Test plan

- [x] `npm run build` succeeds (467 modules transformed, no warnings).
- [ ] Manual: load the portal, verify active filter pills, sidebar selection, and primary buttons remain legible against the new gradient.
- [ ] Reviewer spot-check: paste `#047857` + `#ffffff` into any contrast checker (expected ≥ 4.5:1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)