### PR TITLE
fix(provider): omit temperature param for GPT-5 family models

### DIFF
--- a/backend/providers/openai_provider.py
+++ b/backend/providers/openai_provider.py
@@ -11,6 +11,20 @@ from providers.utils import format_chunks
 logger = logging.getLogger(__name__)
 
 
+# GPT-5 family models reject explicit temperature values other than the
+# default (1). Calling chat.completions.create with temperature=0.2 raises
+# a 400 invalid_request_error. For those models, omit the param entirely so
+# the API uses its default. gpt-4 / gpt-4o / o1 etc. all accept
+# temperature normally.
+_FIXED_TEMPERATURE_PREFIXES = ("gpt-5",)
+
+
+def _temperature_kwargs(model: str, temperature: float) -> dict:
+    if any(model.startswith(prefix) for prefix in _FIXED_TEMPERATURE_PREFIXES):
+        return {}
+    return {"temperature": temperature}
+
+
 class OpenAIProvider(BaseLLMProvider):
     def __init__(self) -> None:
         self._client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
@@ -48,7 +62,7 @@ class OpenAIProvider(BaseLLMProvider):
         resp = await self._client.chat.completions.create(
             model=self._model,
             messages=messages,
-            temperature=0.3,
+            **_temperature_kwargs(self._model, 0.3),
         )
 
         return self._to_response(resp)
@@ -67,7 +81,7 @@ class OpenAIProvider(BaseLLMProvider):
         resp = await self._client.chat.completions.create(
             model=self._model,
             messages=messages,
-            temperature=0.3,
+            **_temperature_kwargs(self._model, 0.3),
         )
 
         return self._to_response(resp)
@@ -94,7 +108,7 @@ class OpenAIProvider(BaseLLMProvider):
         resp = await self._client.chat.completions.create(
             model=self._model,
             messages=messages,
-            temperature=0.4,
+            **_temperature_kwargs(self._model, 0.4),
         )
 
         return self._to_response(resp)
@@ -121,7 +135,7 @@ class OpenAIProvider(BaseLLMProvider):
         resp = await self._client.chat.completions.create(
             model=self._model,
             messages=messages,
-            temperature=0.2,
+            **_temperature_kwargs(self._model, 0.2),
             response_format={"type": "json_object"},
         )
 
@@ -143,7 +157,7 @@ class OpenAIProvider(BaseLLMProvider):
             model=self._model,
             messages=full_messages,
             max_tokens=max_tokens,
-            temperature=0.5,
+            **_temperature_kwargs(self._model, 0.5),
         )
 
         return self._to_response(resp)

--- a/backend/tests/test_openai_temperature_kwargs.py
+++ b/backend/tests/test_openai_temperature_kwargs.py
@@ -1,0 +1,29 @@
+"""Verify the OpenAI provider's temperature-kwargs helper drops the param
+for GPT-5 family models (which reject anything other than the default 1)
+while preserving it for other model families.
+"""
+
+from __future__ import annotations
+
+from providers.openai_provider import _temperature_kwargs
+
+
+def test_gpt5_family_omits_temperature():
+    assert _temperature_kwargs("gpt-5-nano-2025-08-07", 0.2) == {}
+    assert _temperature_kwargs("gpt-5", 0.5) == {}
+    assert _temperature_kwargs("gpt-5-mini", 0.3) == {}
+
+
+def test_gpt4_family_keeps_temperature():
+    assert _temperature_kwargs("gpt-4o-mini", 0.2) == {"temperature": 0.2}
+    assert _temperature_kwargs("gpt-4o", 0.4) == {"temperature": 0.4}
+    assert _temperature_kwargs("gpt-4-turbo", 0.5) == {"temperature": 0.5}
+
+
+def test_o1_family_keeps_temperature():
+    # o1 isn't in our exclusion list — it accepts temperature normally
+    assert _temperature_kwargs("o1-mini", 0.3) == {"temperature": 0.3}
+
+
+def test_unknown_model_keeps_temperature():
+    assert _temperature_kwargs("some-future-model", 0.5) == {"temperature": 0.5}


### PR DESCRIPTION
## Summary

Run #6 against `gpt-5-nano-2025-08-07` returned 220 instances of:

> `Error code: 400 - "Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported."`

Every call fell back to Anthropic. The eval measured Sonnet 4, not GPT-5.

## Fix

Add a small `_temperature_kwargs(model, temperature)` helper at the top of `openai_provider.py` that returns:

- `{}` for any model whose name starts with `"gpt-5"` — the API will use the default temperature (1).
- `{"temperature": <value>}` for everything else (gpt-4 / gpt-4o / o1 / unknown future models).

All 5 generation methods (`generate_grounded_answer`, `generate_summary`, `generate_mod_draft`, `generate_moderation_analysis`, `generate_chat_reply`) now spread `**_temperature_kwargs(self._model, x)` instead of passing temperature directly. Behavior is unchanged for gpt-4o-mini and below.

Forward-compatible: gpt-5, gpt-5-mini, gpt-5-pro, gpt-5-nano-* all match the prefix. If/when OpenAI relaxes the constraint, drop the prefix from `_FIXED_TEMPERATURE_PREFIXES`.

## Why this matters for the eval

We just learned (Run #5 vs Run #6 forced Anthropic-fallback comparison) that **Sonnet 4 is meaningfully better than gpt-4o-mini on the moderation task** — closes the recall-blind rules (12/15/16) and fixes the rule_001/rule_004 over-flag patterns without any prompt changes:

| Rule | gpt-4o-mini (Run #5) | Sonnet 4 fallback (Run #6) |
|---|---|---|
| rule_001 | 0.58 / 1.00 | **1.00** / 1.00 |
| rule_006 | 0.86 / 1.00 | **1.00** / 1.00 |
| rule_012 Voice Chat | 1.00 / **0.20** | 1.00 / **0.90** |
| rule_015 English Only | **0.00 / 0.00** | **1.00 / 0.70** |
| rule_016 Doxxing | 1.00 / 0.20 | 1.00 / **0.70** |

We can't tell whether GPT-5-nano matches, beats, or trails Sonnet 4 until this fix is in.

## Test plan

- [x] 4 new unit tests covering gpt-5 family / gpt-4 family / o1 / unknown-model behaviour
- [x] `pytest backend/tests/` — 342/342 passing (was 338 + 4 new = 342)
- [ ] Post-merge: re-run eval on `iter/eval-expand-high-stakes` to actually measure GPT-5-nano (Run #7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)