### PR TITLE
chore(provider): switch primary to anthropic based on Run #5/#6 evidence

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -8,9 +8,13 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: str = ""
     ANTHROPIC_API_KEY: str = ""
 
-    # Provider selection
-    PRIMARY_PROVIDER: str = "openai"
-    FALLBACK_PROVIDER: str = "anthropic"
+    # Provider selection — primary is Anthropic Sonnet. Run #5 vs Run #6
+    # (220-case eval) showed Sonnet 4 substantially outperforms gpt-4o-mini
+    # on the moderation task: closes recall on rules 12/15/16, fixes
+    # rule_001/rule_004 over-flag, no prompt changes needed. OpenAI stays
+    # as fallback (gpt-5-nano with temperature handling fixed in PR #55).
+    PRIMARY_PROVIDER: str = "anthropic"
+    FALLBACK_PROVIDER: str = "openai"
 
     # Model names
     OPENAI_MODEL: str = "gpt-5-nano-2025-08-07"

--- a/backend/tests/test_chat_provider.py
+++ b/backend/tests/test_chat_provider.py
@@ -182,22 +182,28 @@ async def test_anthropic_generate_chat_reply_passes_system_as_top_level_kwarg():
 async def test_provider_service_dispatches_generate_chat_reply():
     """provider_service.call('generate_chat_reply', ...) exercises the real dispatch.
 
-    The mock target is _PROVIDERS["openai"].generate_chat_reply — one layer BELOW
-    provider_service.call — so the real dispatch logic runs: provider lookup via
-    _get_provider, getattr resolution of method_name, and kwargs forwarding via
-    await fn(**kwargs).  If any of those steps break, this test fails.
+    The mock target is _PROVIDERS[<primary>].generate_chat_reply — one layer
+    BELOW provider_service.call — so the real dispatch logic runs: provider
+    lookup via _get_provider, getattr resolution of method_name, and kwargs
+    forwarding via await fn(**kwargs).  If any of those steps break, this
+    test fails.
+
+    Reads the primary provider from settings so the test stays correct when
+    PRIMARY_PROVIDER changes (was openai, now anthropic).
     """
     import services.provider_service as _ps
+    from config import settings
 
+    primary = settings.PRIMARY_PROVIDER
     expected = ProviderResponse(
         text="locked in, checking that",
-        provider_name="openai",
-        model="gpt-4o-mini",
+        provider_name=primary,
+        model="mock-model",
         usage={"prompt_tokens": 20, "completion_tokens": 5},
     )
     mock_method = AsyncMock(return_value=expected)
 
-    with patch.object(_ps._PROVIDERS["openai"], "generate_chat_reply", mock_method):
+    with patch.object(_ps._PROVIDERS[primary], "generate_chat_reply", mock_method):
         from services import provider_service
 
         result = await provider_service.call(
@@ -213,7 +219,7 @@ async def test_provider_service_dispatches_generate_chat_reply():
         max_tokens=MAX_TOKENS,
     )
     assert result.text == "locked in, checking that"
-    assert result.provider_name == "openai"
+    assert result.provider_name == primary
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

One-line config change: `PRIMARY_PROVIDER: openai → anthropic` (and the corresponding fallback flip). Decision driven by hard data from the eval suite, not preference.

## Evidence (Run #5 vs Run #6)

Run #5 (gpt-4o-mini, 220 cases, 3-shot) vs Run #6 (Sonnet 4 via accidental fallback after the GPT-5 temperature 400, same dataset, same prompt, same vote scheme):

| Metric | gpt-4o-mini | Sonnet 4 |
|---|---|---|
| Total mismatches | 106 / 220 (48.2%) | **86 / 220 (39.1%)** |
| Benign FPR | 0.119 | 0.112 |
| Rules with recall ≤ 0.20 | 5 (7/12/15/16/17) | 2 (7/17) |
| Rules with precision < 0.85 | 6 | 2 |

Sonnet 4 closed the recall blindness on rules **12 (voice chat)**, **15 (English-only)**, and **16 (doxxing)** without any prompt changes, and fixed the rule_001/rule_004 over-flag patterns the gpt-4o-mini-tuned prompt couldn't fully resolve.

## Cost note

Sonnet 4 at $3/MTok input + $15/MTok output runs the full 220-case 3-shot eval at **~$6**. We treat eval runs as a budgeted resource and don't pitch them as ~free.

## Why now (skip Run #7)

GPT-5-nano is unmeasured. Testing it would cost ~$6 and we'd then have to *also* decide if it justifies displacing Sonnet 4. The data we already have validates Sonnet as primary; OpenAI stays warm as fallback (gpt-5-nano with temperature handling fixed in PR #55).

## Test plan

- [x] `pytest backend/tests/` — 346/346 pass (was 342, +4 from PR #55)
- [x] `test_provider_service_dispatches_generate_chat_reply` updated to read `PRIMARY_PROVIDER` from settings rather than hard-coding "openai" — now correct on either side of the swap
- [x] No production code paths needed updating; provider_service routes via `settings.PRIMARY_PROVIDER` already

🤖 Generated with [Claude Code](https://claude.com/claude-code)